### PR TITLE
Add AGENTS.md style guides to prevent common template mistakes

### DIFF
--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,264 @@
+# SPFx Examples Development Style Guide
+
+This guide contains critical guidelines for maintaining SPFx examples. Examples are the rendered output of templates and must stay synchronized with their template definitions.
+
+## Purpose of Examples
+
+Examples serve as:
+1. **Reference implementations** - Show what the template generates
+2. **Test fixtures** - Used in automated tests to verify template output
+3. **Documentation** - Demonstrate how components should be structured
+
+**Golden Rule**: Examples must be generated from templates, never hand-edited directly. Any changes should be made to the template first, then regenerated.
+
+## Naming Conventions in Examples
+
+### String Literal IDs Must Be ALL_CAPS
+
+TypeScript constant IDs should use all uppercase:
+
+```typescript
+// ✅ CORRECT
+public static readonly GENERICCARD_CARD_VIEW = 'GENERICCARD_CARD_VIEW';
+public static readonly SEARCHCARD_QUICK_VIEW = 'SEARCHCARD_QUICK_VIEW';
+
+// ❌ WRONG - Mixed case in IDs
+public static readonly GenericCard_CARD_VIEW = 'GenericCard_CARD_VIEW';
+public static readonly SearchCard_QUICK_VIEW = 'SearchCard_QUICK_VIEW';
+```
+
+**Common locations**:
+- AdaptiveCardExtension view IDs
+- FormCustomizer/FieldCustomizer component IDs
+- Any `public static readonly` string constants
+
+### Localization Keys Must Be Hyphen-Case
+
+Localization string keys should use lowercase with hyphens:
+
+```typescript
+// ✅ CORRECT - in loc/en-us.js
+PropertyPaneDescription: 'generic-card-property-pane'
+SearchCardPropertyDescription: 'search-card-property-pane'
+
+// ❌ WRONG - Capital letters or wrong separators
+PropertyPaneDescription: 'GenericCard-property-pane'
+PropertyPaneDescription: 'generic_card_property_pane'
+```
+
+## Version and Configuration
+
+### package.json Version Consistency
+
+All SPFx dependency versions must match across examples:
+
+```json
+// ✅ CORRECT - Consistent version
+{
+  "@microsoft/sp-core-library": "~1.22.1",
+  "@microsoft/sp-webpart-base": "~1.22.1",
+  "@microsoft/sp-adaptive-card-extension-base": "~1.22.1"
+}
+
+// ❌ WRONG - Mixed versions
+{
+  "@microsoft/sp-core-library": "~1.22.1",
+  "@microsoft/sp-webpart-base": "~1.22.0",  // Different!
+}
+```
+
+### package-solution.json
+
+Version must be properly formatted:
+
+```json
+// ✅ CORRECT
+{
+  "solution": {
+    "version": "1.22.1.0"
+  }
+}
+
+// ❌ WRONG - Malformed version string
+{
+  "solution": {
+    "version": "undefined-1.22.1"
+  }
+}
+```
+
+### README.md Version Badges
+
+Version badges should match package.json SPFx version:
+
+```markdown
+✅ CORRECT
+![version](https://img.shields.io/badge/version-1.22.1-blue)
+
+❌ WRONG
+![version](https://img.shields.io/badge/version-1.22.0-blue)
+```
+
+## Documentation Requirements
+
+### README.md Structure
+
+Every example README should include:
+
+1. **Component Name Header**
+2. **Summary section** with actual description (not placeholder text)
+3. **Used SharePoint Framework Version** badge
+4. **Prerequisites**, **Version history**, etc.
+
+```markdown
+# Generic Card
+
+## Summary
+
+This sample shows how to build an Adaptive Card Extension using the generic card template.
+
+## Used SharePoint Framework Version
+
+![version](https://img.shields.io/badge/version-1.22.1-blue)
+```
+
+❌ **NEVER** leave placeholder text like:
+- "Short summary of your web part"
+- "Description goes here"
+- "<%= description %>"
+
+### Localization Files (loc/*.js)
+
+Property pane descriptions should be meaningful, not template syntax:
+
+```javascript
+// ✅ CORRECT
+define([], function() {
+  return {
+    PropertyPaneDescription: 'Configuration options for Generic Card'
+  }
+});
+
+// ❌ WRONG - Template syntax left in example
+PropertyPaneDescription: '<%= description %>'
+```
+
+## Code Quality Standards
+
+### No Extra Blank Lines
+
+Remove unnecessary blank lines:
+
+```typescript
+// ✅ CORRECT
+import * as React from 'react';
+import * as strings from 'MyStrings';
+
+export default class MyComponent extends React.Component {
+```
+
+```typescript
+// ❌ WRONG - Extra blank lines
+import * as React from 'react';
+import * as strings from 'MyStrings';
+
+
+export default class MyComponent extends React.Component {
+```
+
+### Consistent Formatting
+
+- Use 2-space indentation
+- Remove trailing whitespace
+- Files end with single newline
+- Follow TypeScript/React best practices
+
+## Regenerating Examples
+
+When a template changes, regenerate the corresponding example:
+
+```bash
+# Ensure correct Node version
+export PATH="$HOME/AppData/Local/nvs/node/22.21.1/x64:$PATH"
+
+# Navigate to example directory
+cd examples/ace-generic-card
+
+# Clean and regenerate (using CLI with --local-template flag)
+# Details depend on your specific regeneration workflow
+
+# Verify it builds
+rushx build
+```
+
+**Important**: After regeneration, review the diff to ensure:
+- Only intended changes from template modifications
+- No accidental hand-edits or formatting changes
+- All naming conventions are correct
+- No template syntax (<%=, %>) remains
+
+## Common Issues Checklist
+
+Before committing an example, verify:
+
+- [ ] All TypeScript string literal IDs are ALL_CAPS
+- [ ] All localization keys are hyphen-case (lowercase with hyphens)
+- [ ] README.md has actual content, not placeholder text or template syntax
+- [ ] package.json versions are consistent (all dependencies use same SPFx version)
+- [ ] package-solution.json version is properly formatted (no "undefined")
+- [ ] Version badge in README matches package.json SPFx version
+- [ ] No extra blank lines in source files
+- [ ] No template syntax (<%= %>) remains in any file
+- [ ] Component builds successfully with `rushx build`
+- [ ] Component passes `rushx package-solution`
+
+## Template vs Example Synchronization
+
+Examples must match template output exactly. If you find issues in an example:
+
+1. **Don't fix the example directly** - Fix the template instead
+2. **Update the template** to generate correct output
+3. **Regenerate the example** from the corrected template
+4. **Submit both changes** in the same PR
+
+This ensures templates remain the source of truth and prevents drift.
+
+## Testing Your Example
+
+Before submitting a PR:
+
+```bash
+# Build the example
+export PATH="$HOME/AppData/Local/nvs/node/22.21.1/x64:$PATH"
+cd examples/your-example-name
+rushx build
+
+# Run template comparison tests
+cd ../../tests/templates-test
+rushx test -- -t your-template-name
+```
+
+Tests will fail if:
+- Example doesn't match template output
+- Naming conventions are violated
+- Template syntax remains in files
+
+## Questions?
+
+If you notice:
+- **Incorrect casing in IDs** → This is a template issue, fix the template
+- **Template syntax in example** → Regenerate from template
+- **Version mismatches** → Check template.json spfxVersion variable
+- **Build failures** → Verify Node version and rush update
+
+When in doubt, compare with the webpart-minimal example as the reference implementation.
+
+## Rush Configuration
+
+Examples are registered in `/workspaces/spfx/rush.json` and must:
+- Use consistent version policy
+- Follow naming convention: `examples-<template-name>`
+- Have correct project folder path
+- Be included in template tests
+
+See rush.json projects array for proper configuration format.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,0 +1,211 @@
+# SPFx Template Development Style Guide
+
+This guide contains critical guidelines for creating and maintaining SPFx templates. These rules prevent common mistakes identified in code reviews.
+
+## Template Variable Naming Conventions
+
+### Required Variable Cases
+
+When using component name variables in templates, ensure you use the correct case transformation:
+
+- **ALL_CAPS for TypeScript string literal IDs**: Use `componentNameAllCaps` or manually uppercase
+  ```typescript
+  // ✅ CORRECT
+  public static readonly GENERICCARD_CARD_VIEW = 'GENERICCARD_CARD_VIEW';
+
+  // ❌ WRONG
+  public static readonly GenericCard_CARD_VIEW = 'GenericCard_CARD_VIEW';
+  ```
+
+- **hyphen-case for localization keys**: Use `componentNameHyphenCase`
+  ```typescript
+  // ✅ CORRECT
+  strings.PropertyPaneDescription = 'generic-card-property-pane';
+
+  // ❌ WRONG
+  strings.PropertyPaneDescription = 'GenericCard-property-pane';
+  ```
+
+- **camelCase for TypeScript identifiers**: Use `componentNameCamelCase`
+  ```typescript
+  // ✅ CORRECT
+  export default class GenericCardAdaptiveCardExtension
+  ```
+
+### Missing Template Variables
+
+If you need a case transformation that doesn't exist (e.g., `componentNameAllCaps`), either:
+1. Add it to the template.json contextSchema
+2. OR manually transform in the template using EJS: `<%= componentName.toUpperCase().replace(/[^A-Z0-9]/g, '') %>`
+
+## Description and Documentation Placeholders
+
+### README.md Files
+
+Always use the `<%= description %>` placeholder for user-provided descriptions:
+
+```markdown
+# <%= componentName %>
+
+## Summary
+
+<%= description %>
+
+## Used SharePoint Framework Version
+```
+
+❌ **NEVER** use generic placeholder text like:
+- "Short summary of your web part"
+- "This is the description"
+- "Add your description here"
+
+### Localization Files (loc/*.js)
+
+Property pane descriptions should use placeholders:
+
+```javascript
+// ✅ CORRECT
+PropertyPaneDescription: '<%= description %>',
+
+// ❌ WRONG
+PropertyPaneDescription: 'Description for property pane',
+```
+
+If you're unsure whether to use `description` vs another field, check:
+- **description**: User-provided component description (from CLI prompt)
+- **propertyPaneDescription**: Specific UI text for property pane header
+
+## Version Management
+
+### SPFx Version Consistency
+
+1. **Centralize version numbers**: Always use the `spfxVersion` variable from template.json
+   ```json
+   {
+     "context": {
+       "spfxVersion": "1.22.1"
+     }
+   }
+   ```
+
+2. **In package.json dependencies**: Use `<%= spfxVersion %>`
+   ```json
+   "@microsoft/sp-core-library": "~<%= spfxVersion %>"
+   ```
+
+3. **In README badges**: Use `<%= spfxVersion %>`
+   ```markdown
+   ![version](https://img.shields.io/badge/version-<%= spfxVersion %>-blue)
+   ```
+
+4. **Never hardcode versions**: Avoids version drift and update overhead
+
+### package-solution.json Version Format
+
+Ensure the version string is properly formatted:
+
+```json
+// ✅ CORRECT
+{
+  "version": "<%= spfxVersion %>.0"
+}
+
+// ❌ WRONG - Results in "undefined-1.22.1"
+{
+  "version": "undefined-<%= spfxVersion %>"
+}
+```
+
+## Code Quality Standards
+
+### No Extra Blank Lines
+
+Remove unnecessary blank lines between imports and class declarations:
+
+```typescript
+// ✅ CORRECT
+import * as React from 'react';
+import * as strings from 'MyStrings';
+
+export default class MyComponent extends React.Component {
+```
+
+```typescript
+// ❌ WRONG
+import * as React from 'react';
+import * as strings from 'MyStrings';
+
+
+export default class MyComponent extends React.Component {
+```
+
+### Consistent Formatting
+
+- Use 2-space indentation (matches SPFx generator defaults)
+- Follow existing code formatting in the template
+- Remove trailing whitespace
+- Ensure files end with a single newline
+
+## Template Variable Reference
+
+Common template variables and their use cases:
+
+| Variable | Case | Use For | Example |
+|----------|------|---------|---------|
+| `componentName` | original | User input | "Generic Card" |
+| `componentNameCamelCase` | camelCase | File/folder names | "genericCard" |
+| `componentNameCapitalCase` | PascalCase | Class names | "GenericCard" |
+| `componentNameHyphenCase` | hyphen-case | CSS, IDs, keys | "generic-card" |
+| `componentNameAllCaps` | UPPER_CASE | String IDs | "GENERICCARD" |
+| `libraryName` | scoped | Package name | "@spfx-template/generic-card" |
+| `description` | n/a | User description | User's text |
+| `spfxVersion` | n/a | SPFx version | "1.22.1" |
+
+## Testing Your Template
+
+Before submitting a template PR:
+
+1. **Regenerate the example** from your template:
+   ```bash
+   export PATH="$HOME/AppData/Local/nvs/node/22.21.1/x64:$PATH"
+   cd examples/your-template-name
+   rushx build
+   ```
+
+2. **Check for common issues**:
+   - Search for hardcoded component names (should use variables)
+   - Search for "undefined" in generated files
+   - Verify all description placeholders are used
+   - Check that string IDs are ALL_CAPS
+   - Check that localization keys are hyphen-case
+   - Verify version badge matches spfxVersion
+
+3. **Run template tests**:
+   ```bash
+   cd tests/templates-test
+   rushx test -- -t your-template-name
+   ```
+
+## Common Mistakes Checklist
+
+Before submitting a PR, verify:
+
+- [ ] All TypeScript string literal IDs use ALL_CAPS format
+- [ ] All localization property keys use hyphen-case format
+- [ ] README.md uses `<%= description %>` placeholder
+- [ ] Localization files use description placeholders (not generic text)
+- [ ] All version references use `<%= spfxVersion %>` variable
+- [ ] No "undefined" strings in package-solution.json
+- [ ] No extra blank lines in code
+- [ ] Version badge in README matches spfxVersion
+- [ ] Template variables match their intended use case
+- [ ] Generated example matches template output exactly
+
+## Questions?
+
+If you're unsure about:
+- Which variable to use → Check template.json contextSchema
+- How to format a specific identifier → Look at existing working templates
+- Whether to add a new variable → Consider if it prevents hardcoding
+
+When in doubt, consult the webpart-minimal template as the reference implementation.


### PR DESCRIPTION
## Summary
- Adds AGENTS.md style guides to templates/ and examples/ directories
- Documents common mistakes identified in code reviews (PRs #22-#25)
- Provides clear guidelines to prevent repeated errors

## Why
Code reviews on PRs #22, #23, #24, and #25 identified repeated mistakes:
- String IDs not using ALL_CAPS format
- Localization keys not using hyphen-case
- Missing or incorrect description placeholders
- Hardcoded version numbers instead of using spfxVersion variable
- Extra blank lines in code

These AGENTS.md files will be automatically loaded by Claude Code when working in those directories, providing context-specific guidance.

## Key Guidelines Added

### templates/AGENTS.md
- Template variable naming conventions and use cases
- Description placeholder requirements (use `<%= description %>`)
- Version management (always use `<%= spfxVersion %>`)
- Code quality standards
- Common mistakes checklist
- Testing procedures

### examples/AGENTS.md
- Naming conventions in rendered output (ALL_CAPS for IDs, hyphen-case for keys)
- Version consistency requirements
- Documentation standards (no template syntax in examples)
- Regeneration workflow
- Template synchronization rules

## Test plan
- [x] AGENTS.md files created with comprehensive guidelines
- [x] Memory updated to reference these guides
- [x] Guidelines based on actual code review feedback from Camille

🤖 Generated with [Claude Code](https://claude.com/claude-code)