### PR TITLE
Fix QuickView JSON import: replace require() with static import

### DIFF
--- a/examples/ace-generic-card/src/adaptiveCardExtensions/genericCard/quickView/QuickView.ts
+++ b/examples/ace-generic-card/src/adaptiveCardExtensions/genericCard/quickView/QuickView.ts
@@ -4,6 +4,7 @@ import {
   IGenericCardAdaptiveCardExtensionProps,
   IGenericCardAdaptiveCardExtensionState
 } from '../GenericCardAdaptiveCardExtension';
+import QuickViewTemplate from './template/QuickViewTemplate.json';
 
 export interface IQuickViewData {
   subTitle: string;
@@ -23,7 +24,6 @@ export class QuickView extends BaseAdaptiveCardQuickView<
   }
 
   public get template(): ISPFxAdaptiveCard {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('./template/QuickViewTemplate.json');
+    return QuickViewTemplate as unknown as ISPFxAdaptiveCard;
   }
 }

--- a/examples/ace-generic-card/tsconfig.json
+++ b/examples/ace-generic-card/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/@microsoft/spfx-web-build-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/@microsoft/spfx-web-build-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }

--- a/templates/ace-generic-card/src/adaptiveCardExtensions/{componentNameCamelCase}/quickView/QuickView.ts
+++ b/templates/ace-generic-card/src/adaptiveCardExtensions/{componentNameCamelCase}/quickView/QuickView.ts
@@ -4,6 +4,7 @@ import {
   I<%= componentNameCapitalCase %>AdaptiveCardExtensionProps,
   I<%= componentNameCapitalCase %>AdaptiveCardExtensionState
 } from '../<%= componentNameCapitalCase %>AdaptiveCardExtension';
+import QuickViewTemplate from './template/QuickViewTemplate.json';
 
 export interface IQuickViewData {
   subTitle: string;
@@ -23,7 +24,6 @@ export class QuickView extends BaseAdaptiveCardQuickView<
   }
 
   public get template(): ISPFxAdaptiveCard {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('./template/QuickViewTemplate.json');
+    return QuickViewTemplate as unknown as ISPFxAdaptiveCard;
   }
 }

--- a/templates/ace-generic-card/tsconfig.json
+++ b/templates/ace-generic-card/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/@microsoft/spfx-web-build-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/@microsoft/spfx-web-build-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }


### PR DESCRIPTION
## Summary
- Replace `require('./template/QuickViewTemplate.json')` + `eslint-disable` comment with a proper static `import` in `QuickView.ts`
- Add `resolveJsonModule: true` to `tsconfig.json` to enable typed JSON imports
- Applies to both the `ace-generic-card` template and example

## Test plan
- [ ] Verify `rushx build` passes for `examples/ace-generic-card`
- [ ] Verify no `@typescript-eslint/no-var-requires` lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)