### PR TITLE
Enable versioning for published packages

### DIFF
--- a/api/spfx-template-api/package.json
+++ b/api/spfx-template-api/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@microsoft/spfx-template-api",
   "description": "Library for generating SPFx solutions",
-  "version": "1.0.0",
-  "private": true,
+  "version": "0.0.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/apps/spfx-cli/package.json
+++ b/apps/spfx-cli/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@microsoft/spfx-cli",
   "description": "Project scaffolding and other tools for SharePoint Framework (SPFx) development",
-  "version": "1.0.0",
-  "private": true,
+  "version": "0.0.0",
   "main": "lib/index.js",
   "license": "MIT",
   "engines": {

--- a/common/changes/@microsoft/spfx-cli/versioning_2026-03-04-03-01.json
+++ b/common/changes/@microsoft/spfx-cli/versioning_2026-03-04-03-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/spfx-cli",
+      "comment": "Initial release.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/spfx-cli"
+}

--- a/common/config/rush/.npmrc-publish
+++ b/common/config/rush/.npmrc-publish
@@ -18,3 +18,6 @@
 #
 #   //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
 #
+
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+registry=https://registry.npmjs.org/

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -99,4 +99,10 @@
   //
   //   // "includeEmailInChangeFile": true
   // }
+  {
+    "definitionName": "lockStepVersion",
+    "policyName": "spfx",
+    "version": "0.0.0",
+    "mainProject": "@microsoft/spfx-cli"
+  }
 ]

--- a/rush.json
+++ b/rush.json
@@ -429,14 +429,14 @@
       "packageName": "@microsoft/spfx-cli",
       "projectFolder": "apps/spfx-cli",
       "reviewCategory": "apps",
-      "shouldPublish": false,
+      "versionPolicyName": "spfx",
       "tags": []
     },
     {
       "packageName": "@microsoft/spfx-template-api",
       "projectFolder": "api/spfx-template-api",
       "reviewCategory": "libraries",
-      "shouldPublish": false,
+      "versionPolicyName": "spfx",
       "tags": []
     },
 


### PR DESCRIPTION
## Summary
- Configure lockstep version policy (`spfx`) for the two published packages: `@microsoft/spfx-cli`, `@microsoft/spfx-template-api`
- Remove `"private": true` and set initial version to `0.0.0` for these packages
- Add npm auth token reference to `.npmrc-publish` for CI publishing
- Add `versionPolicyName: "spfx"` to the project entries in `rush.json`

## Test plan
- [ ] Verify `rush update` and `rush build` succeed
- [ ] Verify `rush change` prompts for changes to the published packages
- [ ] Verify `rush version --bump` correctly processes change files

🤖 Generated with [Claude Code](https://claude.com/claude-code)