### PR TITLE
Sort dependencies alphabetically across all templates and examples

### DIFF
--- a/examples/ace-data-visualization/package.json
+++ b/examples/ace-data-visualization/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/ace-generic-card/package.json
+++ b/examples/ace-generic-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/ace-generic-image-card/package.json
+++ b/examples/ace-generic-image-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/ace-generic-primarytext-card/package.json
+++ b/examples/ace-generic-primarytext-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/ace-search-card/package.json
+++ b/examples/ace-search-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/extension-application-customizer/package.json
+++ b/examples/extension-application-customizer/package.json
@@ -12,26 +12,26 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-application-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-dialog": "1.22.2",
-    "@microsoft/sp-application-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "overrides": {
     "@rushstack/heft": "^1.1.6"

--- a/examples/extension-fieldcustomizer-minimal/package.json
+++ b/examples/extension-fieldcustomizer-minimal/package.json
@@ -13,24 +13,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-listview-extensibility": "1.22.2"
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-listview-extensibility": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/extension-fieldcustomizer-noframework/package.json
+++ b/examples/extension-fieldcustomizer-noframework/package.json
@@ -13,24 +13,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-listview-extensibility": "1.22.2"
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-listview-extensibility": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/extension-fieldcustomizer-react/package.json
+++ b/examples/extension-fieldcustomizer-react/package.json
@@ -13,32 +13,32 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@fluentui/react": "^8.106.4",
+    "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-listview-extensibility": "1.22.2",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-core-library": "1.22.2",
-    "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-listview-extensibility": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "~5.8.3",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "resolutions": {
     "@types/react": "17.0.45"

--- a/examples/extension-formcustomizer-noframework/package.json
+++ b/examples/extension-formcustomizer-noframework/package.json
@@ -12,26 +12,26 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-listview-extensibility": "1.22.2",
     "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/extension-formcustomizer-react/package.json
+++ b/examples/extension-formcustomizer-react/package.json
@@ -12,34 +12,34 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
     "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-listview-extensibility": "1.22.2",
     "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "~5.8.3",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "resolutions": {
     "@types/react": "17.0.45"

--- a/examples/extension-listviewcommandset/package.json
+++ b/examples/extension-listviewcommandset/package.json
@@ -12,26 +12,26 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-dialog": "1.22.2",
     "@microsoft/sp-listview-extensibility": "1.22.2",
-    "@microsoft/sp-dialog": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "overrides": {
     "@rushstack/heft": "^1.1.6"

--- a/examples/extension-search-query-modifier/package.json
+++ b/examples/extension-search-query-modifier/package.json
@@ -12,25 +12,25 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-search-extensibility": "1.22.2"
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-search-extensibility": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "overrides": {
     "@rushstack/heft": "^1.1.6"

--- a/examples/library/package.json
+++ b/examples/library/package.json
@@ -15,18 +15,18 @@
     "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/webpart-minimal/package.json
+++ b/examples/webpart-minimal/package.json
@@ -12,27 +12,27 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-component-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-lodash-subset": "1.22.2",
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
     "@microsoft/sp-webpart-base": "1.22.2",
-    "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "^8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/webpart-noframework/package.json
+++ b/examples/webpart-noframework/package.json
@@ -12,27 +12,27 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-component-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-lodash-subset": "1.22.2",
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
     "@microsoft/sp-webpart-base": "1.22.2",
-    "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "^8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/examples/webpart-react/package.json
+++ b/examples/webpart-react/package.json
@@ -12,35 +12,35 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
     "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-component-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-lodash-subset": "1.22.2",
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
     "@microsoft/sp-webpart-base": "1.22.2",
-    "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "~5.8.3",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "resolutions": {
     "@types/react": "17.0.45"

--- a/templates/ace-data-visualization/package.json
+++ b/templates/ace-data-visualization/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/ace-generic-card/package.json
+++ b/templates/ace-generic-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/ace-generic-image-card/package.json
+++ b/templates/ace-generic-image-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/ace-generic-primarytext-card/package.json
+++ b/templates/ace-generic-primarytext-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/ace-search-card/package.json
+++ b/templates/ace-search-card/package.json
@@ -12,24 +12,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
     "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
-    "@microsoft/sp-adaptive-card-extension-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/extension-application-customizer/package.json
+++ b/templates/extension-application-customizer/package.json
@@ -12,26 +12,26 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-application-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-dialog": "1.22.2",
-    "@microsoft/sp-application-base": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "overrides": {
     "@rushstack/heft": "^1.1.6"

--- a/templates/extension-fieldcustomizer-minimal/package.json
+++ b/templates/extension-fieldcustomizer-minimal/package.json
@@ -13,24 +13,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-listview-extensibility": "1.22.2"
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-listview-extensibility": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/extension-fieldcustomizer-noframework/package.json
+++ b/templates/extension-fieldcustomizer-noframework/package.json
@@ -13,24 +13,24 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-listview-extensibility": "1.22.2"
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-listview-extensibility": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/extension-fieldcustomizer-react/package.json
+++ b/templates/extension-fieldcustomizer-react/package.json
@@ -13,32 +13,32 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
+    "@fluentui/react": "^8.106.4",
+    "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-listview-extensibility": "1.22.2",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-core-library": "1.22.2",
-    "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-listview-extensibility": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "~5.8.3",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "resolutions": {
     "@types/react": "17.0.45"

--- a/templates/extension-formcustomizer-noframework/package.json
+++ b/templates/extension-formcustomizer-noframework/package.json
@@ -12,26 +12,26 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-listview-extensibility": "1.22.2",
     "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/extension-formcustomizer-react/package.json
+++ b/templates/extension-formcustomizer-react/package.json
@@ -12,34 +12,34 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
     "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-listview-extensibility": "1.22.2",
     "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "~5.8.3",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "resolutions": {
     "@types/react": "17.0.45"

--- a/templates/extension-listviewcommandset/package.json
+++ b/templates/extension-listviewcommandset/package.json
@@ -12,26 +12,26 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-dialog": "1.22.2",
     "@microsoft/sp-listview-extensibility": "1.22.2",
-    "@microsoft/sp-dialog": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "overrides": {
     "@rushstack/heft": "^1.1.6"

--- a/templates/extension-search-query-modifier/package.json
+++ b/templates/extension-search-query-modifier/package.json
@@ -12,25 +12,25 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/decorators": "1.22.2",
-    "@microsoft/sp-search-extensibility": "1.22.2"
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-search-extensibility": "1.22.2",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "overrides": {
     "@rushstack/heft": "^1.1.6"

--- a/templates/library/package.json
+++ b/templates/library/package.json
@@ -15,18 +15,18 @@
     "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/webpart-minimal/package.json
+++ b/templates/webpart-minimal/package.json
@@ -12,27 +12,27 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-component-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-lodash-subset": "1.22.2",
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
     "@microsoft/sp-webpart-base": "1.22.2",
-    "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "^8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/webpart-noframework/package.json
+++ b/templates/webpart-noframework/package.json
@@ -12,27 +12,27 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-component-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-lodash-subset": "1.22.2",
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
     "@microsoft/sp-webpart-base": "1.22.2",
-    "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "^8.57.1",
-    "typescript": "~5.8.3",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   }
 }

--- a/templates/webpart-react/package.json
+++ b/templates/webpart-react/package.json
@@ -12,35 +12,35 @@
     "eject-webpack": "heft eject-webpack"
   },
   "dependencies": {
-    "tslib": "2.3.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
     "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-core-library": "1.22.2",
     "@microsoft/sp-component-base": "1.22.2",
+    "@microsoft/sp-core-library": "1.22.2",
+    "@microsoft/sp-lodash-subset": "1.22.2",
+    "@microsoft/sp-office-ui-fabric-core": "1.22.2",
     "@microsoft/sp-property-pane": "1.22.2",
     "@microsoft/sp-webpart-base": "1.22.2",
-    "@microsoft/sp-lodash-subset": "1.22.2",
-    "@microsoft/sp-office-ui-fabric-core": "1.22.2"
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "4.6.1",
-    "@microsoft/eslint-plugin-spfx": "1.22.2",
     "@microsoft/eslint-config-spfx": "1.22.2",
-    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@microsoft/eslint-plugin-spfx": "1.22.2",
+    "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-heft-plugins": "1.22.2",
+    "@microsoft/spfx-web-build-rig": "1.22.2",
+    "@rushstack/eslint-config": "4.6.1",
     "@rushstack/heft": "^1.1.6",
     "@types/heft-jest": "^1.0.6",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "css-loader": "~7.1.2",
     "eslint": "8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "~5.8.3",
-    "@types/react": "17.0.45",
-    "@types/react-dom": "17.0.17",
-    "@microsoft/sp-module-interfaces": "1.22.2"
+    "typescript": "~5.8.3"
   },
   "resolutions": {
     "@types/react": "17.0.45"


### PR DESCRIPTION
## Summary
- Sort `dependencies` and `devDependencies` alphabetically in all 34 template and example `package.json` files

Fixes #38

## Test plan
- [x] All 68 dependency sections verified sorted via script
- [x] `rush update` succeeds
- [x] `rush build --to tag:build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)