### PR TITLE
Specify the default remote in rush.json.

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -214,12 +214,14 @@
      * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
      * to retrieve the latest activity for the remote main branch.
      */
-    // "url": "https://github.com/microsoft/rush-example",
+    "url": "https://github.com/SharePoint/spfx",
+
     /**
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "main"
      */
-    // "defaultBranch": "main",
+    "defaultBranch": "main"
+
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is
      * not set or if a remote matching the provided remote URL is not found.


### PR DESCRIPTION
## Description

Specifies the default remote in `rush.json` to ensure `rush change` has the correct basis for comparison.

## How was this tested?

N/A

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Template change
- [x] Documentation / CI / governance
