### PR TITLE
Add SPFx CLI architecture RFC design document

### DIFF
--- a/common/docs/spfx-cli-architecture.md
+++ b/common/docs/spfx-cli-architecture.md
@@ -150,14 +150,13 @@ The class can be constructed from a folder on disk (`fromFolderAsync`) or from
 in-memory data (`fromMemoryAsync`). It exposes a `renderAsync()` method that
 processes text files through EJS with the provided context object (while copying
 binary assets unchanged) and returns a rendered file set. In the current
-implementation, `SPFxTemplate` also exposes a `write(memFs)` helper that the CLI
+implementation, `SPFxTemplate` also exposes a `write()` helper that the CLI
 calls to persist the rendered output to disk.
 
-> **Planned change:** The render output currently uses `MemFsEditor` directly.
-> This will be replaced with a minimal wrapper interface so that the `mem-fs`
-> dependency can be removed without a breaking API change. A separate
-> `SPFxTemplateWriter` class will be introduced to handle inspecting rendered
-> output and applying merge logic before committing changes to disk.
+> **Planned change:** `renderAsync()` will return an `ISPFxTemplateFileSet`
+> interface that we define and own, rather than exposing a third-party type. A
+> separate `SPFxTemplateWriter` class will be introduced to handle inspecting
+> rendered output and applying merge logic before committing changes to disk.
 
 Filenames support `{variableName}` placeholder syntax — e.g.
 `src/webparts/{componentNameCamelCase}WebPart.ts` is resolved using the render
@@ -257,10 +256,9 @@ import {
   SPFxTemplateRepositoryManager,
   LocalFileSystemRepositorySource,
   SPFxTemplateCollection,
-  SPFxTemplate
+  SPFxTemplate,
+  ISPFxTemplateFileSet
 } from '@microsoft/spfx-template-api';
-import { MemFsEditor, create } from 'mem-fs-editor';
-import { create as createMemFs } from 'mem-fs';
 
 async function scaffold(): Promise<void> {
   // Create a manager and register template sources
@@ -276,7 +274,7 @@ async function scaffold(): Promise<void> {
   const template: SPFxTemplate = templates.get('webpart-minimal')!;
 
   // Render with context variables
-  const editor: MemFsEditor = await template.renderAsync(
+  const fileSet: ISPFxTemplateFileSet = await template.renderAsync(
     {
       solution_name: 'my-solution',
       componentNameCamelCase: 'helloWorld',
@@ -297,8 +295,8 @@ async function scaffold(): Promise<void> {
     '/path/to/output'
   );
 
-  // Write to disk (current: direct write via template helper)
-  await template.write(editor);
+  // Write to disk
+  await template.write(fileSet);
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds the SPFx CLI architecture RFC design document to `common/docs/spfx-cli-architecture.md`.

This document was produced by:

1. Starting from the agreed-upon V3 dev plan ("SPFx CLI – Architecture") as the authoritative source.
2. Reviewing three prior iterations of the dev plan (V0: original Yeoman deprecation mini-plan, V1: 1.22-beta.1 scoped dev plan, V2: full engineering design with example API) to identify design context that was understated or assumed in V3. In particular:
   - **Motivation** (from V0) — why we are moving away from Yeoman (legacy maintenance mode, closed-source templates, high support cost, coupled release cadence).
   - **Download mechanism** (from V1) — the GitHub Codeload URL construction pattern, which survived into the actual implementation.
   - **Example API usage** (from V2) — illustrative code showing how the scaffolding API composes, which helps readers understand the overall flow.
   - **Out-of-scope items** (from V2) — explicit boundaries (internal NPM feed CI, odsp-web integration, gulp-core-build).
3. Auditing the actual codebase to correct class names, file names, CLI parameters, and repo structure that had drifted from what V3 described (e.g. `SPFxTemplateJsonFile` not `SPFxTemplateManifestFile`, `template.json` not `template.manifest.json`, `--target-dir` not `--directory`).
4. Incorporating details from currently open PR #128 (MergeHelpers & SPFxTemplateWriter implementation) — specifically the render/write separation in `SPFxTemplate`, the `SPFxTemplateWriter` detection mechanism (`dump()` + `existsSync()`), and confirming the writer is a public API rather than internal-only.

All internal references (names, dates, timelines, cost estimates, links to internal spec docs, comment annotations) have been stripped.

## How was this tested

Documentation only — no code changes.

## Type of change

- [x] Documentation change

🤖 Generated with [Claude Code](https://claude.com/claude-code)