### PR TITLE
Fix install-run-rush lockfile path to use RepoPath parameter

### DIFF
--- a/common/config/azure-pipelines/templates/install-run-rush.yaml
+++ b/common/config/azure-pipelines/templates/install-run-rush.yaml
@@ -20,4 +20,4 @@ steps:
     ${{ if ne(parameters.Condition, '') }}:
       condition: ${{ parameters.Condition }}
     env:
-      INSTALL_RUN_RUSH_LOCKFILE_PATH: $(Build.SourcesDirectory)/common/config/validation/rush-package-lock.json
+      INSTALL_RUN_RUSH_LOCKFILE_PATH: ${{ parameters.RepoPath }}/common/config/validation/rush-package-lock.json


### PR DESCRIPTION
## Description

Fixes `INSTALL_RUN_RUSH_LOCKFILE_PATH` in the `install-run-rush` pipeline template to use `${{ parameters.RepoPath }}` instead of `$(Build.SourcesDirectory)`.

`$(Build.SourcesDirectory)` resolves to the default checkout location, which is incorrect when the repo is checked out to a non-default path (e.g. `s/self`, as done in `bump-versions.yaml` to accommodate the multi-repo workspace layout).

## How was this tested

Code review.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Template change
- [x] Docs/CI