### PR TITLE
Upgrade checkout action from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       INSTALL_RUN_RUSH_LOCKFILE_PATH: ${{ github.workspace }}/common/config/validation/rush-package-lock.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
## Description

Upgrade checkout action from v4 to v6 to avoid a Node 20 warning.

## How was this tested?

Ran CI jobs.

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Template change
- [x] Documentation / CI / governance
