### PR TITLE
Add version/** branches to CI pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           node-version: ${{ matrix.nodeVersion }}
 
       - name: Verify Change Logs
+        # Only required when targeting main — version/** branches are not used for publishing releases
         if: (github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name != 'pull_request' && github.ref_name == 'main')
         run: node common/scripts/install-run-rush.js change --verify
 


### PR DESCRIPTION
## Description

Adds `version/**` to the `pull_request` branches filter in the CI workflow, so that pull requests targeting version release branches also run CI.

Also adjusts the "Verify Change Logs" step to only run when targeting `main` — changelog verification is not required for `version/**` branches since we don't publish releases from them.

## How was this tested

Verified the CI YAML is valid and the logic is correct by inspection.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Template change
- [x] Docs/CI change