### PR TITLE
Update .npmignore to broaden map exclusions and add test file patterns

### DIFF
--- a/common/changes/@microsoft/spfx-cli/update-npmignore-patterns_2026-03-25.json
+++ b/common/changes/@microsoft/spfx-cli/update-npmignore-patterns_2026-03-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/spfx-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/spfx-cli"
+}

--- a/examples/ace-data-visualization/.npmignore
+++ b/examples/ace-data-visualization/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/ace-generic-card/.npmignore
+++ b/examples/ace-generic-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/ace-generic-image-card/.npmignore
+++ b/examples/ace-generic-image-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/ace-generic-primarytext-card/.npmignore
+++ b/examples/ace-generic-primarytext-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/ace-search-card/.npmignore
+++ b/examples/ace-search-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-application-customizer/.npmignore
+++ b/examples/extension-application-customizer/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-fieldcustomizer-minimal/.npmignore
+++ b/examples/extension-fieldcustomizer-minimal/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-fieldcustomizer-noframework/.npmignore
+++ b/examples/extension-fieldcustomizer-noframework/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-fieldcustomizer-react/.npmignore
+++ b/examples/extension-fieldcustomizer-react/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-formcustomizer-noframework/.npmignore
+++ b/examples/extension-formcustomizer-noframework/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-formcustomizer-react/.npmignore
+++ b/examples/extension-formcustomizer-react/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-listviewcommandset/.npmignore
+++ b/examples/extension-listviewcommandset/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/extension-search-query-modifier/.npmignore
+++ b/examples/extension-search-query-modifier/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/library/.npmignore
+++ b/examples/library/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/webpart-minimal/.npmignore
+++ b/examples/webpart-minimal/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/webpart-noframework/.npmignore
+++ b/examples/webpart-noframework/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/examples/webpart-react/.npmignore
+++ b/examples/webpart-react/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/ace-data-visualization/.npmignore
+++ b/templates/ace-data-visualization/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/ace-generic-card/.npmignore
+++ b/templates/ace-generic-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/ace-generic-image-card/.npmignore
+++ b/templates/ace-generic-image-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/ace-generic-primarytext-card/.npmignore
+++ b/templates/ace-generic-primarytext-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/ace-search-card/.npmignore
+++ b/templates/ace-search-card/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-application-customizer/.npmignore
+++ b/templates/extension-application-customizer/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-fieldcustomizer-minimal/.npmignore
+++ b/templates/extension-fieldcustomizer-minimal/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-fieldcustomizer-noframework/.npmignore
+++ b/templates/extension-fieldcustomizer-noframework/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-fieldcustomizer-react/.npmignore
+++ b/templates/extension-fieldcustomizer-react/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-formcustomizer-noframework/.npmignore
+++ b/templates/extension-formcustomizer-noframework/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-formcustomizer-react/.npmignore
+++ b/templates/extension-formcustomizer-react/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-listviewcommandset/.npmignore
+++ b/templates/extension-listviewcommandset/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/extension-search-query-modifier/.npmignore
+++ b/templates/extension-search-query-modifier/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/library/.npmignore
+++ b/templates/library/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/webpart-minimal/.npmignore
+++ b/templates/webpart-minimal/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/webpart-noframework/.npmignore
+++ b/templates/webpart-noframework/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.

--- a/templates/webpart-react/.npmignore
+++ b/templates/webpart-react/.npmignore
@@ -11,10 +11,12 @@
 
 # Ignore certain files in the above folders
 /dist/*.stats.*
-/dist/**/*.js.map
-/lib/**/*.js.map
+/dist/**/*.map
+/lib/**/*.map
+/lib/**/*.test.*
 /lib/**/test/**
-/lib-*/**/*.js.map
+/lib-*/**/*.map
+/lib-*/**/*.test.*
 /lib-*/**/test/**
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.


### PR DESCRIPTION
## Description

Updates `.npmignore` across all 34 templates and examples to improve npm package exclusions, as suggested by @iclanton in PR #13.

**Changes:**
- Broadened `*.js.map` → `*.map` to exclude all source map types (`.css.map`, `.d.ts.map`, etc.), not just JavaScript maps
- Added `*.test.*` exclusion patterns for `lib/` and `lib-*/` directories to prevent test files from being published

Fixes #35

## How was this tested

- `rush build` — all 22 projects build successfully
- `rushx test` in `tests/spfx-template-test/` — all 19 template tests pass
- `rushx test` in `apps/spfx-cli/` — all 80 CLI tests pass

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Template change
- [ ] Docs / CI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)