### PR TITLE
Clean up outdated .gitignore and .vscode/settings.json entries

### DIFF
--- a/common/changes/@microsoft/spfx-cli/cleanup-gitignore-vscode-settings_2026-03-25.json
+++ b/common/changes/@microsoft/spfx-cli/cleanup-gitignore-vscode-settings_2026-03-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/spfx-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/spfx-cli"
+}

--- a/examples/ace-data-visualization/.gitignore
+++ b/examples/ace-data-visualization/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/ace-data-visualization/.vscode/settings.json
+++ b/examples/ace-data-visualization/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/ace-generic-card/.gitignore
+++ b/examples/ace-generic-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/ace-generic-card/.vscode/settings.json
+++ b/examples/ace-generic-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/ace-generic-image-card/.gitignore
+++ b/examples/ace-generic-image-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/ace-generic-image-card/.vscode/settings.json
+++ b/examples/ace-generic-image-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/ace-generic-primarytext-card/.gitignore
+++ b/examples/ace-generic-primarytext-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/ace-generic-primarytext-card/.vscode/settings.json
+++ b/examples/ace-generic-primarytext-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/ace-search-card/.gitignore
+++ b/examples/ace-search-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/ace-search-card/.vscode/settings.json
+++ b/examples/ace-search-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-application-customizer/.gitignore
+++ b/examples/extension-application-customizer/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-application-customizer/.vscode/settings.json
+++ b/examples/extension-application-customizer/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-fieldcustomizer-minimal/.gitignore
+++ b/examples/extension-fieldcustomizer-minimal/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-fieldcustomizer-minimal/.vscode/settings.json
+++ b/examples/extension-fieldcustomizer-minimal/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-fieldcustomizer-noframework/.gitignore
+++ b/examples/extension-fieldcustomizer-noframework/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-fieldcustomizer-noframework/.vscode/settings.json
+++ b/examples/extension-fieldcustomizer-noframework/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-fieldcustomizer-react/.gitignore
+++ b/examples/extension-fieldcustomizer-react/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-fieldcustomizer-react/.vscode/settings.json
+++ b/examples/extension-fieldcustomizer-react/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-formcustomizer-noframework/.gitignore
+++ b/examples/extension-formcustomizer-noframework/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-formcustomizer-noframework/.vscode/settings.json
+++ b/examples/extension-formcustomizer-noframework/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-formcustomizer-react/.gitignore
+++ b/examples/extension-formcustomizer-react/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-listviewcommandset/.gitignore
+++ b/examples/extension-listviewcommandset/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-listviewcommandset/.vscode/settings.json
+++ b/examples/extension-listviewcommandset/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/extension-search-query-modifier/.gitignore
+++ b/examples/extension-search-query-modifier/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/extension-search-query-modifier/.vscode/settings.json
+++ b/examples/extension-search-query-modifier/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
   "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/library/.gitignore
+++ b/examples/library/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/library/.vscode/settings.json
+++ b/examples/library/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/webpart-minimal/.gitignore
+++ b/examples/webpart-minimal/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/webpart-minimal/.vscode/settings.json
+++ b/examples/webpart-minimal/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/webpart-noframework/.gitignore
+++ b/examples/webpart-noframework/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/webpart-noframework/.vscode/settings.json
+++ b/examples/webpart-noframework/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/examples/webpart-react/.gitignore
+++ b/examples/webpart-react/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/examples/webpart-react/.vscode/settings.json
+++ b/examples/webpart-react/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/ace-data-visualization/.gitignore
+++ b/templates/ace-data-visualization/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/ace-data-visualization/.vscode/settings.json
+++ b/templates/ace-data-visualization/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/ace-generic-card/.gitignore
+++ b/templates/ace-generic-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/ace-generic-card/.vscode/settings.json
+++ b/templates/ace-generic-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/ace-generic-image-card/.gitignore
+++ b/templates/ace-generic-image-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/ace-generic-image-card/.vscode/settings.json
+++ b/templates/ace-generic-image-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/ace-generic-primarytext-card/.gitignore
+++ b/templates/ace-generic-primarytext-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/ace-generic-primarytext-card/.vscode/settings.json
+++ b/templates/ace-generic-primarytext-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/ace-search-card/.gitignore
+++ b/templates/ace-search-card/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/ace-search-card/.vscode/settings.json
+++ b/templates/ace-search-card/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-application-customizer/.gitignore
+++ b/templates/extension-application-customizer/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-application-customizer/.vscode/settings.json
+++ b/templates/extension-application-customizer/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-fieldcustomizer-minimal/.gitignore
+++ b/templates/extension-fieldcustomizer-minimal/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-fieldcustomizer-minimal/.vscode/settings.json
+++ b/templates/extension-fieldcustomizer-minimal/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-fieldcustomizer-noframework/.gitignore
+++ b/templates/extension-fieldcustomizer-noframework/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-fieldcustomizer-noframework/.vscode/settings.json
+++ b/templates/extension-fieldcustomizer-noframework/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-fieldcustomizer-react/.gitignore
+++ b/templates/extension-fieldcustomizer-react/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-fieldcustomizer-react/.vscode/settings.json
+++ b/templates/extension-fieldcustomizer-react/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-formcustomizer-noframework/.gitignore
+++ b/templates/extension-formcustomizer-noframework/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-formcustomizer-noframework/.vscode/settings.json
+++ b/templates/extension-formcustomizer-noframework/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-formcustomizer-react/.gitignore
+++ b/templates/extension-formcustomizer-react/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-listviewcommandset/.gitignore
+++ b/templates/extension-listviewcommandset/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-listviewcommandset/.vscode/settings.json
+++ b/templates/extension-listviewcommandset/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/extension-search-query-modifier/.gitignore
+++ b/templates/extension-search-query-modifier/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/extension-search-query-modifier/.vscode/settings.json
+++ b/templates/extension-search-query-modifier/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
   "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/library/.gitignore
+++ b/templates/library/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/library/.vscode/settings.json
+++ b/templates/library/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/webpart-minimal/.gitignore
+++ b/templates/webpart-minimal/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/webpart-minimal/.vscode/settings.json
+++ b/templates/webpart-minimal/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/webpart-noframework/.gitignore
+++ b/templates/webpart-noframework/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/webpart-noframework/.vscode/settings.json
+++ b/templates/webpart-noframework/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/templates/webpart-react/.gitignore
+++ b/templates/webpart-react/.gitignore
@@ -33,6 +33,3 @@ obj
 
 # Resx Generated Code
 *.resx.ts
-
-# Styles Generated Code
-*.scss.ts

--- a/templates/webpart-react/.vscode/settings.json
+++ b/templates/webpart-react/.vscode/settings.json
@@ -2,13 +2,9 @@
 {
   // Configure glob patterns for excluding files and folders in the file explorer.
   "files.exclude": {
-    "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
-    "**/jest-output": true,
-    "**/lib-amd": true,
-    "src/**/*.scss.ts": true
+    "**/jest-output": true
   },
-  "typescript.tsdk": ".\\node_modules\\typescript\\lib"
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Description

Remove outdated entries from `.gitignore` and `.vscode/settings.json` across all templates and examples, as raised by @iclanton in PR #13.

**`.gitignore` (34 files):**
- Remove `*.scss.ts` — these are no longer generated in `src/`

**`.vscode/settings.json` (32 files):**
- Remove `"**/.git": true` — VS Code hides `.git` by default
- Remove `"**/bower_components": true` — Bower is no longer used
- Remove `"**/lib-amd": true` — AMD build target is no longer used
- Remove `"src/**/*.scss.ts": true` — scss.ts files no longer generated
- Normalize `typescript.tsdk` path to use forward slashes for cross-platform portability

Fixes #40

## How was this tested?

- `rush build` — full build passes
- `rushx test` in `tests/spfx-template-test` — all 19 template tests pass (examples match templates)
- `rushx build` verified on `examples/webpart-minimal` and `examples/webpart-react`
- Grep confirms zero remaining instances of removed entries

## Type of change
- [x] Template change

🤖 Generated with [Claude Code](https://claude.com/claude-code)