### PR TITLE
Remove redundant mock call in changelog section test

### DIFF
--- a/tools/repo-toolbox/src/utilities/test/PackageTgzUtilities.test.ts
+++ b/tools/repo-toolbox/src/utilities/test/PackageTgzUtilities.test.ts
@@ -78,8 +78,6 @@ describe(readChangelogSectionFromTgzAsync.name, () => {
   });
 
   it('does not match a version that is a prefix of another version', async () => {
-    mockTarStdout(changelog);
-
     // '1.0.0' should not match '## 1.0.0-alpha.1' or similar
     const changelogWithPrerelease: string = [
       '# Changelog',


### PR DESCRIPTION
## Summary
- Removes a `mockTarStdout(changelog)` call at the top of the \"does not match a version that is a prefix of another version\" test that was immediately overridden by `mockTarStdout(changelogWithPrerelease)` inside the test body.

## How was this tested
- `rushx build` + `heft test` — all 15 tests pass.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Template change
- [x] Docs/CI/test improvement