### PR TITLE
Add coding standards to CLAUDE.md from PR review feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ This is the single most important coding convention in this repo. **Never** use 
 | `fs.readFile(p)` / `fs.readFileSync(p)` | `FileSystem.readFileAsync(p)` |
 | `fs.readFile(p)` (binary) | `FileSystem.readFileToBufferAsync(p)` |
 | `fs.readdir(p)` / `fs.readdirSync(p)` | `FileSystem.readFolderItemsAsync(p)` |
-| `fs.writeFile(p, data)` / `fs.writeFileSync(p, data)` | `FileSystem.writeFileAsync(p, { content, ensureFolderExists: true })` |
+| `fs.writeFile(p, data)` / `fs.writeFileSync(p, data)` | `FileSystem.writeFileAsync(p, content, { ensureFolderExists: true })` |
 | `(error as any)?.code !== 'ENOENT'` | `FileSystem.isNotExistError(error)` |
 | `JSON.parse(text)` | `JsonFile.parseString(text)` (preserves comments via `jju`) |
 | `JSON.stringify(obj)` | `JsonFile.updateString(original, obj)` (preserves comments and formatting) |


### PR DESCRIPTION
## Summary
- Analyzed all ~75 PRs in this repo and synthesized Ian's review comments into actionable coding standards in CLAUDE.md
- Covers: `node-core-library` over raw Node APIs, template strings over `path.join`, `import` over `require()`, type imports from existing packages, TypeScript patterns (`interface` over `class`, `Map` over records, `override` keyword, optional chaining over `!:`), test conventions (snapshots, `ClassName.name` in describes), template/example hygiene (sorted deps, no redundant configs, localized strings), error handling, merge logic, and changelog discipline
- Goal: generate code that passes review on the first try by encoding these conventions directly into the AI assistant's instructions

## How was this tested
- [x] Reviewed all PR comments from iclanton across the repo history
- [x] Cross-referenced patterns to ensure accuracy and completeness
- [x] Verified CLAUDE.md renders correctly

## Type of change
- [x] Documentation / CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)