### PR TITLE
Use 1ES PT-provided GITHUB_TOKEN for release creation

### DIFF
--- a/common/config/azure-pipelines/spfx-esrp-publish.yaml
+++ b/common/config/azure-pipelines/spfx-esrp-publish.yaml
@@ -218,8 +218,6 @@ extends:
                     value: $[ stageDependencies.Prepare.PrepareSpfxPublish.outputs['FindBumpRun.BumpPipelineRunId'] ]
                   - name: BumpCommitSha
                     value: $[ stageDependencies.Prepare.PrepareSpfxPublish.outputs['FindBumpRun.BumpCommitSha'] ]
-                  - name: GitHubToken
-                    value: $[ stageDependencies.Prepare.PrepareSpfxPublish.outputs['EmitGitHubVars.GitHubToken'] ]
                   - name: GitHubRepoSlug
                     value: $[ stageDependencies.Prepare.PrepareSpfxPublish.outputs['EmitGitHubVars.GitHubRepoSlug'] ]
                 steps:
@@ -251,6 +249,4 @@ extends:
                         --packages-path "$(PackagesPath)"
                         --commit-sha "$(BumpCommitSha)"
                         --repo-slug "$(GitHubRepoSlug)"
-                    env:
-                      GITHUB_TOKEN: $(GitHubToken)
                     displayName: 'Create GitHub releases'

--- a/tools/repo-toolbox/src/cli/actions/CreateGitHubReleasesAction.ts
+++ b/tools/repo-toolbox/src/cli/actions/CreateGitHubReleasesAction.ts
@@ -54,7 +54,7 @@ export class CreateGitHubReleasesAction extends CommandLineAction {
       argumentName: 'TOKEN',
       environmentVariable: 'GITHUB_TOKEN',
       description:
-        'GitHub Authorization header value for creating releases (format: `basic <base64>` as emitted by emit-github-vars-and-tag-build).',
+        'GitHub token for creating releases. Accepts a raw installation token (e.g. `ghs_xxx`) or a full Authorization header value (e.g. `basic <base64>`).',
       required: true
     });
 

--- a/tools/repo-toolbox/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/tools/repo-toolbox/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -10,11 +10,11 @@ Optional arguments:
   -h, --help            Show this help message and exit.
   --packages-path PATH  Path to directory containing .tgz package files.
   --commit-sha SHA      The commit SHA to tag.
-  --github-token TOKEN  GitHub Authorization header value for creating
-                        releases (format: \`basic <base64>\` as emitted by
-                        emit-github-vars-and-tag-build). This parameter may
-                        alternatively be specified via the GITHUB_TOKEN
-                        environment variable.
+  --github-token TOKEN  GitHub token for creating releases. Accepts a raw
+                        installation token (e.g. \`ghs_xxx\`) or a full
+                        Authorization header value (e.g. \`basic <base64>\`).
+                        This parameter may alternatively be specified via the
+                        GITHUB_TOKEN environment variable.
   --repo-slug SLUG      GitHub repository slug in the form owner/repo.
 "
 `;

--- a/tools/repo-toolbox/src/utilities/GitHubClient.ts
+++ b/tools/repo-toolbox/src/utilities/GitHubClient.ts
@@ -74,7 +74,11 @@ export class GitHubClient {
 
     this._octokit = new Octokit();
     this._octokit.hook.before('request', (requestOptions) => {
-      requestOptions.headers.authorization = authorizationHeader;
+      // If the value contains a space, it is already a full HTTP Authorization header value
+      // (e.g. "basic <base64>" or "token <value>"). Otherwise, treat it as a raw bearer token.
+      requestOptions.headers.authorization = authorizationHeader.includes(' ')
+        ? authorizationHeader
+        : `token ${authorizationHeader}`;
     });
   }
 


### PR DESCRIPTION
## Description

The `create-github-releases` pipeline step was overriding `GITHUB_TOKEN` with the git checkout credential emitted by `emit-github-vars-and-tag-build`. That credential is generated by AzDO with limited scope (git operations only), which causes a 403 \"Resource not accessible by integration\" error when used to create GitHub releases via the REST API.

The 1ES pipeline template injects a properly-scoped `GITHUB_TOKEN` into the job environment via its \"Get GitHub Token\" step. Removing the `env: GITHUB_TOKEN: $(GitHubToken)` override and the now-unused `GitHubToken` variable mapping lets that token be used instead.

Also normalizes raw bearer tokens (no space prefix) to `token <value>` format in `GitHubClient`, so the code handles both the old `basic <base64>` format and a plain installation token interchangeably.

## How was this tested

Build against the pipeline; the prior behavior (override with checkout credential) was confirmed to produce a 403 on multiple runs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Template change (affects `templates/` and `examples/`)
- [x] Docs/CI/pipeline change