### PR TITLE
Add .spfx-scaffold.jsonl to .gitignore in all templates, examples, and test fixtures

### DIFF
--- a/examples/ace-data-visualization/.gitignore
+++ b/examples/ace-data-visualization/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/ace-generic-card/.gitignore
+++ b/examples/ace-generic-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/ace-generic-image-card/.gitignore
+++ b/examples/ace-generic-image-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/ace-generic-primarytext-card/.gitignore
+++ b/examples/ace-generic-primarytext-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/ace-search-card/.gitignore
+++ b/examples/ace-search-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-application-customizer/.gitignore
+++ b/examples/extension-application-customizer/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-fieldcustomizer-minimal/.gitignore
+++ b/examples/extension-fieldcustomizer-minimal/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-fieldcustomizer-noframework/.gitignore
+++ b/examples/extension-fieldcustomizer-noframework/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-fieldcustomizer-react/.gitignore
+++ b/examples/extension-fieldcustomizer-react/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-formcustomizer-noframework/.gitignore
+++ b/examples/extension-formcustomizer-noframework/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-formcustomizer-react/.gitignore
+++ b/examples/extension-formcustomizer-react/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-listviewcommandset/.gitignore
+++ b/examples/extension-listviewcommandset/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/extension-search-query-modifier/.gitignore
+++ b/examples/extension-search-query-modifier/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/library/.gitignore
+++ b/examples/library/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/test/.gitignore
+++ b/examples/test/.gitignore
@@ -1,0 +1,1 @@
+.spfx-scaffold.jsonl

--- a/examples/webpart-minimal/.gitignore
+++ b/examples/webpart-minimal/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/webpart-noframework/.gitignore
+++ b/examples/webpart-noframework/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/examples/webpart-react/.gitignore
+++ b/examples/webpart-react/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/ace-data-visualization/.gitignore
+++ b/templates/ace-data-visualization/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/ace-generic-card/.gitignore
+++ b/templates/ace-generic-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/ace-generic-image-card/.gitignore
+++ b/templates/ace-generic-image-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/ace-generic-primarytext-card/.gitignore
+++ b/templates/ace-generic-primarytext-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/ace-search-card/.gitignore
+++ b/templates/ace-search-card/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-application-customizer/.gitignore
+++ b/templates/extension-application-customizer/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-fieldcustomizer-minimal/.gitignore
+++ b/templates/extension-fieldcustomizer-minimal/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-fieldcustomizer-noframework/.gitignore
+++ b/templates/extension-fieldcustomizer-noframework/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-fieldcustomizer-react/.gitignore
+++ b/templates/extension-fieldcustomizer-react/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-formcustomizer-noframework/.gitignore
+++ b/templates/extension-formcustomizer-noframework/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-formcustomizer-react/.gitignore
+++ b/templates/extension-formcustomizer-react/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-listviewcommandset/.gitignore
+++ b/templates/extension-listviewcommandset/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/extension-search-query-modifier/.gitignore
+++ b/templates/extension-search-query-modifier/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/library/.gitignore
+++ b/templates/library/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/webpart-minimal/.gitignore
+++ b/templates/webpart-minimal/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/webpart-noframework/.gitignore
+++ b/templates/webpart-noframework/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/templates/webpart-react/.gitignore
+++ b/templates/webpart-react/.gitignore
@@ -18,6 +18,7 @@ solution
 temp
 *.sppkg
 .heft
+.spfx-scaffold.jsonl
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/tests/spfx-template-test/src/tests/__snapshots__/templates.test.ts.snap
+++ b/tests/spfx-template-test/src/tests/__snapshots__/templates.test.ts.snap
@@ -1001,11 +1001,12 @@ Found 1 template:
 [gray]┌──────[default][gray]┬──────────[default][gray]┬──────────────────────────[default][gray]┬─────────[default][gray]┬──────────────[default][gray]┬───────┐[default]
 [gray]│[default][red] Name [default][gray]│[default][red] Category [default][gray]│[default][red] Description              [default][gray]│[default][red] Version [default][gray]│[default][red] SPFx Version [default][gray]│[default][red] Files [default][gray]│[default]
 [gray]├──────[default][gray]┼──────────[default][gray]┼──────────────────────────[default][gray]┼─────────[default][gray]┼──────────────[default][gray]┼───────┤[default]
-[gray]│[default] test [gray]│[default] webpart  [gray]│[default] A test template for SPFx [gray]│[default] 0.0.1   [gray]│[default] 1.22.0       [gray]│[default] 1     [gray]│[default]
+[gray]│[default] test [gray]│[default] webpart  [gray]│[default] A test template for SPFx [gray]│[default] 0.0.1   [gray]│[default] 1.22.0       [gray]│[default] 2     [gray]│[default]
 [gray]└──────[default][gray]┴──────────[default][gray]┴──────────────────────────[default][gray]┴─────────[default][gray]┴──────────────[default][gray]┴───────┘[default]
 targetDir: <TARGET_DIR>
 
 [cyan]The following files will be generated:[default]
+[green]  .gitignore[default]
 [green]  hello_world.md[default]
 
 "

--- a/tests/spfx-template-test/test-template/.gitignore
+++ b/tests/spfx-template-test/test-template/.gitignore
@@ -1,0 +1,1 @@
+.spfx-scaffold.jsonl


### PR DESCRIPTION
## Description

The scaffold log (`.spfx-scaffold.jsonl`) is now persisted to disk by the CLI after every `spfx create` run (#221). This PR adds it to `.gitignore` in every template, example, and test fixture so it doesn't appear as an untracked file in generated projects.

**Followed by** #229, which uses the scaffold log location and the `package.json` engines field as the source of truth for the selected package manager.

## How was this tested

- `rushx build` in `tests/spfx-template-test` — snapshot updated to reflect that templates now emit a `.gitignore` file (file count 1→2).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Template change (modifies template files or examples)
- [ ] Docs / CI change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)