### PR TITLE
Add version flag to spfx-cli

### DIFF
--- a/apps/spfx-cli/src/cli/SPFxCommandLineParser.ts
+++ b/apps/spfx-cli/src/cli/SPFxCommandLineParser.ts
@@ -6,15 +6,39 @@ import type { Terminal } from '@rushstack/terminal';
 
 import { CreateAction } from './actions/CreateAction';
 import { ListTemplatesAction } from './actions/ListTemplatesAction';
+import packageJson from '../../package.json';
+
+const CLI_VERSION: string = packageJson.version;
 
 export class SPFxCommandLineParser extends CommandLineParser {
+  private readonly _terminal: Terminal;
+
   public constructor(terminal: Terminal) {
     super({
       toolFilename: 'spfx',
       toolDescription: 'CLI for managing SharePoint Framework (SPFx) projects'
     });
 
+    this._terminal = terminal;
+
+    this.defineFlagParameter({
+      parameterLongName: '--version',
+      parameterShortName: '-v',
+      description: 'Show the CLI version and exit.'
+    });
+
     this.addAction(new CreateAction(terminal));
     this.addAction(new ListTemplatesAction(terminal));
+  }
+
+  public override async executeWithoutErrorHandlingAsync(args?: string[]): Promise<void> {
+    const effectiveArgs: string[] = args ?? process.argv.slice(2);
+
+    if (effectiveArgs.length === 1 && (effectiveArgs[0] === '--version' || effectiveArgs[0] === '-v')) {
+      this._terminal.writeLine(CLI_VERSION);
+      return;
+    }
+
+    await super.executeWithoutErrorHandlingAsync(args);
   }
 }

--- a/apps/spfx-cli/src/cli/test/CommandLineHelp.test.ts
+++ b/apps/spfx-cli/src/cli/test/CommandLineHelp.test.ts
@@ -4,6 +4,7 @@
 import { AnsiEscape, Terminal, StringBufferTerminalProvider } from '@rushstack/terminal';
 
 import { SPFxCommandLineParser } from '../SPFxCommandLineParser';
+import packageJson from '../../../package.json';
 
 describe('CommandLineHelp', () => {
   beforeEach(() => {
@@ -36,5 +37,16 @@ describe('CommandLineHelp', () => {
       );
       expect(actionHelpText).toMatchSnapshot(action.actionName);
     }
+  });
+
+  it.each(['--version', '-v'])('prints the CLI version for %s', async (versionFlag) => {
+    const terminalProvider: StringBufferTerminalProvider = new StringBufferTerminalProvider();
+    const parser: SPFxCommandLineParser = new SPFxCommandLineParser(new Terminal(terminalProvider));
+
+    await parser.executeWithoutErrorHandlingAsync([versionFlag]);
+
+    expect(terminalProvider.getAllOutputAsChunks({ asLines: true })).toEqual([
+      `[    log] ${packageJson.version}[n]`
+    ]);
   });
 });

--- a/apps/spfx-cli/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/spfx-cli/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -60,7 +60,7 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help: global help 1`] = `
-"usage: spfx [-h] <command> ...
+"usage: spfx [-h] [-v] <command> ...
 
 CLI for managing SharePoint Framework (SPFx) projects
 
@@ -72,6 +72,7 @@ Positional arguments:
 
 Optional arguments:
   -h, --help      Show this help message and exit.
+  -v, --version   Show the CLI version and exit.
 
 [bold]For detailed help about a specific command, use: spfx <command> -h[normal]
 "


### PR DESCRIPTION
## Description
Adds a version flag `-v, --version option besides the -h, --help` as requested by #237 

## How was this tested?
`node apps/spfx-cli/bin/spfx --version`

```
source ~/.nvm/nvm.sh
nvm use 22
node apps/spfx-cli/bin/spfx --version
node apps/spfx-cli/bin/spfx -v
```

## Type of change
- [ ] Bug fix
- [X] New feature / enhancement
- [ ] Template change
- [ ] Documentation / CI / governance
