### PR TITLE
Update Rushstack projects (Rush 5.175.0, @rushstack/* bumps)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ const filePath = `${tempDir}/config/package-solution.json`;
 ### Template and Example Standards
 
 - **Sort `dependencies` and `devDependencies` alphabetically** in `package.json`.
-- **Don't include direct dependencies that come from the rig** (e.g., `css-loader`, `@typescript-eslint/parser`, `@types/webpack-env`, `@types/heft-jest`, `@microsoft/spfx-heft-plugins`).
+- **Don't include direct dependencies that come from the rig** (e.g., `css-loader`, `@typescript-eslint/parser`, `@types/webpack-env`, `@types/jest`, `@microsoft/spfx-heft-plugins`).
 - **Remove config files that are redundant with `rig.json`** (e.g., `config/sass.json`, `config/typescript.json` when their values are defaults).
 - **Localize hardcoded UI strings** using the `loc/` pattern.
 - **Use `import` for images**, not `require()`.

--- a/api/spfx-template-api/package.json
+++ b/api/spfx-template-api/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@microsoft/spfx-heft-plugins": "1.22.2",
-    "@rushstack/node-core-library": "~5.21.0",
-    "@rushstack/terminal": "~0.22.4",
+    "@rushstack/node-core-library": "~5.23.1",
+    "@rushstack/terminal": "~0.23.0",
     "adm-zip": "^0.5.16",
     "cli-table3": "^0.6.5",
     "ejs": "^3.1.10",
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@microsoft/spfx-cli-build-rig": "workspace:*",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/adm-zip": "^0.5.5",
     "@types/ejs": "^3.1.5",
     "@types/lodash": "^4.17.18",

--- a/api/spfx-template-api/src/repositories/test/__snapshots__/PublicGitHubRepositorySource.test.ts.snap
+++ b/api/spfx-template-api/src/repositories/test/__snapshots__/PublicGitHubRepositorySource.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PublicGitHubRepositorySource _buildDownloadUrl should build GHE REST API URL for non-github.com hosts 1`] = `Array []`;
 

--- a/api/spfx-template-api/src/writing/test/__snapshots__/PackageManagerEnginesHelper.test.ts.snap
+++ b/api/spfx-template-api/src/writing/test/__snapshots__/PackageManagerEnginesHelper.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`writePackageManagerToPackageJsonEnginesAsync detects version and writes for npm: terminal output 1`] = `Array []`;
 

--- a/api/spfx-template-api/src/writing/test/__snapshots__/SPFxTemplateWriter.test.ts.snap
+++ b/api/spfx-template-api/src/writing/test/__snapshots__/SPFxTemplateWriter.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SPFxTemplateWriter scaffold log integration should record a "merged" file-write event with mergeHelper name 1`] = `
 Array [

--- a/apps/spfx-cli/package.json
+++ b/apps/spfx-cli/package.json
@@ -17,14 +17,14 @@
   },
   "dependencies": {
     "@microsoft/spfx-template-api": "workspace:*",
-    "@rushstack/node-core-library": "~5.21.0",
-    "@rushstack/ts-command-line": "~5.3.4",
-    "@rushstack/terminal": "~0.22.4",
+    "@rushstack/node-core-library": "~5.23.1",
+    "@rushstack/ts-command-line": "~5.3.8",
+    "@rushstack/terminal": "~0.23.0",
     "zod": "^4.1.5"
   },
   "devDependencies": {
     "@microsoft/spfx-cli-build-rig": "workspace:*",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "eslint": "9.37.0"
   }
 }

--- a/apps/spfx-cli/src/cli/actions/tests/__snapshots__/CreateAction.test.ts.snap
+++ b/apps/spfx-cli/src/cli/actions/tests/__snapshots__/CreateAction.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CreateAction --package-manager calls writePackageManagerToPackageJsonEnginesAsync after a successful install 1`] = `
 Array [

--- a/apps/spfx-cli/src/cli/actions/tests/__snapshots__/ListTemplatesAction.test.ts.snap
+++ b/apps/spfx-cli/src/cli/actions/tests/__snapshots__/ListTemplatesAction.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ListTemplatesAction --local-source (additive) adds LocalFileSystemRepositorySource AND still includes the default GitHub source 1`] = `
 Array [

--- a/apps/spfx-cli/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/spfx-cli/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CommandLineHelp prints the help: create 1`] = `
 "usage: spfx create [-h] [--template-url URL] [--spfx-version VERSION]

--- a/common/autoinstallers/plugins/package.json
+++ b/common/autoinstallers/plugins/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@rushstack/rush-published-versions-json-plugin": "0.1.2"
+    "@rushstack/rush-published-versions-json-plugin": "0.1.8"
   }
 }

--- a/common/autoinstallers/plugins/pnpm-lock.yaml
+++ b/common/autoinstallers/plugins/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@rushstack/rush-published-versions-json-plugin':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.1.8
+        version: 0.1.8
 
 packages:
 
@@ -26,35 +26,27 @@ packages:
     resolution: {integrity: sha512-GucC9h/EVbU03Kl7M/FqVes1s5RCQaGCW2f41lFA7VqqHWQElR6k1q33iF6f6fXDUSCdzB1IUxSq9ghP2J+8Pw==}
     engines: {node: '>=18.12'}
 
-  '@rushstack/credential-cache@0.2.7':
-    resolution: {integrity: sha512-5vYUGreyf0ZvQ5lLFsQHLbJe1//hBZeI8G7BMoyDaLt4/uegfHNTmiXgYNXDQaqpnM9ImHyXSuOS/DrcbM3aMA==}
+  '@rushstack/credential-cache@0.2.15':
+    resolution: {integrity: sha512-Wl6xTWYRA0vWi4zzbBfXV6kmwNpdHMaYpr6hueDtEfoo5NujfPoL2RFeGmQr5Vy4cB5xY7LJDh/A4fJRx1qKFA==}
 
-  '@rushstack/lookup-by-path@0.9.7':
-    resolution: {integrity: sha512-wlyXv5n0scQF7DEcv4KcFxsoVbSLXfZhVvS91S6gc6fOWpLoqIzSGANY9yIQtQpyJqrr0vwLUppa+zv/CB4sYw==}
+  '@rushstack/lookup-by-path@0.10.4':
+    resolution: {integrity: sha512-tOUFYpiaOWGkYM+pSOYjlmgHjHVmuldjq9duRa3IQv0Ho0/vZZUg2v8D65ydnQ1WK4MkqnkLeZU85jkV6275Tw==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/node-core-library@5.20.3':
-    resolution: {integrity: sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==}
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/node-core-library@5.21.0':
-    resolution: {integrity: sha512-LFzN+1lyWROit/P8Md6yxAth7lLYKn37oCKJHirEE2TQB25NDUM7bALf0ar+JAtwFfRCH+D+DGOA7DAzIi2r+g==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/package-deps-hash@4.7.7':
-    resolution: {integrity: sha512-nj7wspFmch+SmPr6RT46zO9aKGD6IjVBP8z3JMmiiJq5p7WgNyqEENOBWGZ42Hwpav9qjj9hWxMggHJiwLg3mA==}
+  '@rushstack/package-deps-hash@4.7.15':
+    resolution: {integrity: sha512-2P+/X5K8l+Hjqa2nyjNOD8DY3uvu3Y7SP8iTfRudnV13voi4Wmwbw6Jh8Inif+v+pLj/tcZS9M3uweU2jDuRUg==}
 
   '@rushstack/problem-matcher@0.2.1':
     resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
@@ -64,22 +56,14 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/rush-published-versions-json-plugin@0.1.2':
-    resolution: {integrity: sha512-vJk42NERVgJaX1QqlWSuNoMQw7JPzZS/Vec6uko3711NbWbdQgcf0bkGNyTReaCPlPlB0BbQwLGFlSVJEvMuYA==}
+  '@rushstack/rush-published-versions-json-plugin@0.1.8':
+    resolution: {integrity: sha512-ryE4+uZVYGLwP71lj3ac/174auFhZ9bhV23iw78P2pPxlVPOw5JgIbGLnxewZT5wGcghEzMAawPcknwLtvwN8Q==}
 
-  '@rushstack/rush-sdk@5.172.1':
-    resolution: {integrity: sha512-/szoWiIML50LD4Zmsbzflkw4pC7P8DwPvMqszaOeMT6ahxEBnf2F3Ptfn6rlEFvSVpiV7ESab2wGuAc+wlSTBg==}
+  '@rushstack/rush-sdk@5.175.0':
+    resolution: {integrity: sha512-Fs7Q2Rb378QH8zIeAD5r0Uud5+6Ntop85PUm+sJwe6vQant6pytsdJz4QIRKyecRzdQ9R2CAcfLilC14CClykQ==}
 
-  '@rushstack/terminal@0.22.3':
-    resolution: {integrity: sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/terminal@0.22.4':
-    resolution: {integrity: sha512-fhtLjnXCc/4WleVbVl6aoc7jcWnU6yqjS1S8WoaNREG3ycu/viZ9R/9QM7Y/b4CDvcXoiDyMNIay7JMwBptM3g==}
+  '@rushstack/terminal@0.23.0':
+    resolution: {integrity: sha512-7FfI9irLqnBDxCvMEXdEXLDjaouZsGbKkeGfmW8IOn8aYi7DV9aaXaEQHCcVxWMvEDOkuTf4y6RMDgIY5CFuUQ==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -105,6 +89,10 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -125,8 +113,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   import-lazy@4.0.0:
@@ -146,10 +134,6 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -157,13 +141,13 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -183,9 +167,6 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
 snapshots:
 
   '@pnpm/lockfile.types@900.0.0':
@@ -197,15 +178,15 @@ snapshots:
 
   '@pnpm/types@900.0.0': {}
 
-  '@rushstack/credential-cache@0.2.7':
+  '@rushstack/credential-cache@0.2.15':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3
+      '@rushstack/node-core-library': 5.23.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/lookup-by-path@0.9.7': {}
+  '@rushstack/lookup-by-path@0.10.4': {}
 
-  '@rushstack/node-core-library@5.20.3':
+  '@rushstack/node-core-library@5.23.1':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -213,57 +194,40 @@ snapshots:
       fs-extra: 11.3.4
       import-lazy: 4.0.0
       jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
+      resolve: 1.22.12
+      semver: 7.7.4
 
-  '@rushstack/node-core-library@5.21.0':
+  '@rushstack/package-deps-hash@4.7.15':
     dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.4
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
-
-  '@rushstack/package-deps-hash@4.7.7':
-    dependencies:
-      '@rushstack/node-core-library': 5.20.3
+      '@rushstack/node-core-library': 5.23.1
     transitivePeerDependencies:
       - '@types/node'
 
   '@rushstack/problem-matcher@0.2.1': {}
 
-  '@rushstack/rush-published-versions-json-plugin@0.1.2':
+  '@rushstack/rush-published-versions-json-plugin@0.1.8':
     dependencies:
-      '@rushstack/node-core-library': 5.21.0
-      '@rushstack/rush-sdk': 5.172.1
-      '@rushstack/terminal': 0.22.4
+      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/rush-sdk': 5.175.0
+      '@rushstack/terminal': 0.23.0
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/rush-sdk@5.172.1':
+  '@rushstack/rush-sdk@5.175.0':
     dependencies:
       '@pnpm/lockfile.types-900': '@pnpm/lockfile.types@900.0.0'
-      '@rushstack/credential-cache': 0.2.7
-      '@rushstack/lookup-by-path': 0.9.7
-      '@rushstack/node-core-library': 5.20.3
-      '@rushstack/package-deps-hash': 4.7.7
-      '@rushstack/terminal': 0.22.3
+      '@rushstack/credential-cache': 0.2.15
+      '@rushstack/lookup-by-path': 0.10.4
+      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/package-deps-hash': 4.7.15
+      '@rushstack/terminal': 0.23.0
       tapable: 2.2.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/terminal@0.22.3':
+  '@rushstack/terminal@0.23.0':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3
-      '@rushstack/problem-matcher': 0.2.1
-      supports-color: 8.1.1
-
-  '@rushstack/terminal@0.22.4':
-    dependencies:
-      '@rushstack/node-core-library': 5.21.0
+      '@rushstack/node-core-library': 5.23.1
       '@rushstack/problem-matcher': 0.2.1
       supports-color: 8.1.1
 
@@ -282,6 +246,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  es-errors@1.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
@@ -298,7 +264,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -306,7 +272,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   jju@1.4.0: {}
 
@@ -318,23 +284,18 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-
   path-parse@1.0.7: {}
 
   require-from-string@2.0.2: {}
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
+      es-errors: 1.3.0
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
+  semver@7.7.4: {}
 
   supports-color@8.1.1:
     dependencies:
@@ -345,5 +306,3 @@ snapshots:
   tapable@2.2.1: {}
 
   universalify@2.0.1: {}
-
-  yallist@4.0.0: {}

--- a/common/changes/@microsoft/spfx-cli/update-rushstack-projects_2026-04-18-17-52.json
+++ b/common/changes/@microsoft/spfx-cli/update-rushstack-projects_2026-04-18-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/spfx-cli"
+    }
+  ],
+  "packageName": "@microsoft/spfx-cli",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "fast-xml-parser": "^5.3.5"
   },
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,13 +24,13 @@ importers:
     dependencies:
       '@microsoft/spfx-heft-plugins':
         specifier: 1.22.2
-        version: 1.22.2(patch_hash=185ffebb2de7b1fb5f6ad4d92e9d8ad3b2d3207721e8db14e7ac1f3d716d0b1a)(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)
+        version: 1.22.2(patch_hash=185ffebb2de7b1fb5f6ad4d92e9d8ad3b2d3207721e8db14e7ac1f3d716d0b1a)(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)
       '@rushstack/node-core-library':
-        specifier: ~5.21.0
-        version: 5.21.0(@types/node@22.19.13)
+        specifier: ~5.23.1
+        version: 5.23.1(@types/node@22.19.13)
       '@rushstack/terminal':
-        specifier: ~0.22.4
-        version: 0.22.4(@types/node@22.19.13)
+        specifier: ~0.23.0
+        version: 0.23.0(@types/node@22.19.13)
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/spfx-cli-build-rig
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/adm-zip':
         specifier: ^0.5.5
         version: 0.5.7
@@ -84,14 +84,14 @@ importers:
         specifier: workspace:*
         version: link:../../api/spfx-template-api
       '@rushstack/node-core-library':
-        specifier: ~5.21.0
-        version: 5.21.0(@types/node@22.19.13)
+        specifier: ~5.23.1
+        version: 5.23.1(@types/node@22.19.13)
       '@rushstack/terminal':
-        specifier: ~0.22.4
-        version: 0.22.4(@types/node@22.19.13)
+        specifier: ~0.23.0
+        version: 0.23.0(@types/node@22.19.13)
       '@rushstack/ts-command-line':
-        specifier: ~5.3.4
-        version: 5.3.4(@types/node@22.19.13)
+        specifier: ~5.3.8
+        version: 5.3.8(@types/node@22.19.13)
       zod:
         specifier: ^4.1.5
         version: 4.3.6
@@ -100,8 +100,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/spfx-cli-build-rig
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       eslint:
         specifier: 9.37.0
         version: 9.37.0
@@ -137,8 +137,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -186,8 +186,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -235,8 +235,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -284,8 +284,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -333,8 +333,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -385,8 +385,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -434,8 +434,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -483,8 +483,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -541,8 +541,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -608,8 +608,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -672,8 +672,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -736,8 +736,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -785,8 +785,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -825,8 +825,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -883,8 +883,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -941,8 +941,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -1008,8 +1008,8 @@ importers:
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -1047,14 +1047,14 @@ importers:
         specifier: workspace:*
         version: link:../../api/spfx-template-api
       '@rushstack/node-core-library':
-        specifier: ~5.21.0
-        version: 5.21.0(@types/node@22.19.13)
+        specifier: ~5.23.1
+        version: 5.23.1(@types/node@22.19.13)
       '@rushstack/terminal':
-        specifier: ~0.22.4
-        version: 0.22.4(@types/node@22.19.13)
+        specifier: ~0.23.0
+        version: 0.23.0(@types/node@22.19.13)
       '@rushstack/ts-command-line':
-        specifier: ~5.3.4
-        version: 5.3.4(@types/node@22.19.13)
+        specifier: ~5.3.8
+        version: 5.3.8(@types/node@22.19.13)
       ignore:
         specifier: ^5.3.0
         version: 5.3.2
@@ -1063,8 +1063,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/spfx-cli-build-rig
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       eslint:
         specifier: 9.37.0
         version: 9.37.0
@@ -1081,14 +1081,14 @@ importers:
         specifier: ^16.0.0
         version: 16.0.0
       '@rushstack/node-core-library':
-        specifier: ~5.21.0
-        version: 5.21.0(@types/node@22.19.13)
+        specifier: ~5.23.1
+        version: 5.23.1(@types/node@22.19.13)
       '@rushstack/terminal':
-        specifier: ~0.22.4
-        version: 0.22.4(@types/node@22.19.13)
+        specifier: ~0.23.0
+        version: 0.23.0(@types/node@22.19.13)
       '@rushstack/ts-command-line':
-        specifier: ~5.3.4
-        version: 5.3.4(@types/node@22.19.13)
+        specifier: ~5.3.8
+        version: 5.3.8(@types/node@22.19.13)
       azure-devops-node-api:
         specifier: ^14.1.0
         version: 14.1.0
@@ -1097,14 +1097,14 @@ importers:
         specifier: workspace:*
         version: link:../spfx-cli-build-rig
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       '@rushstack/heft-webpack5-plugin':
-        specifier: ^1.3.10
-        version: 1.3.10(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)(webpack@5.105.4)
+        specifier: ^1.3.16
+        version: 1.3.16(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)(webpack@5.105.4)
       '@rushstack/webpack-preserve-dynamic-require-plugin':
-        specifier: ^0.12.10
-        version: 0.12.10
+        specifier: ^0.12.16
+        version: 0.12.16
       eslint:
         specifier: 9.37.0
         version: 9.37.0
@@ -1115,14 +1115,14 @@ importers:
   ../../tools/spfx-cli-build-rig:
     dependencies:
       '@microsoft/api-extractor':
-        specifier: ^7.58.0
-        version: 7.58.0(@types/node@22.19.13)
+        specifier: ^7.58.5
+        version: 7.58.5(@types/node@22.19.13)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@9.37.0)(typescript@5.8.3)
       '@rushstack/heft-node-rig':
-        specifier: ^2.11.29
-        version: 2.11.29(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)(jest-environment-jsdom@29.5.0)
+        specifier: ^2.11.37
+        version: 2.11.37(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)
       '@types/heft-jest':
         specifier: ^1.0.6
         version: 1.0.6
@@ -1152,8 +1152,8 @@ importers:
         version: 5.8.3
     devDependencies:
       '@rushstack/heft':
-        specifier: ^1.2.9
-        version: 1.2.9(@types/node@22.19.13)
+        specifier: ^1.2.15
+        version: 1.2.15(@types/node@22.19.13)
       eslint:
         specifier: 9.37.0
         version: 9.37.0
@@ -1390,6 +1390,15 @@ packages:
   '@ctrl/tinycolor@3.6.1':
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
     engines: {node: '>=10'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -2101,6 +2110,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -2113,9 +2126,22 @@ packages:
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/console@30.3.0':
+    resolution: {integrity: sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/core@29.5.0':
     resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/core@30.3.0':
+    resolution: {integrity: sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -2126,12 +2152,20 @@ packages:
     resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/diff-sequences@30.3.0':
+    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/environment@29.7.0':
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/environment@30.2.0':
     resolution: {integrity: sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/environment@30.3.0':
+    resolution: {integrity: sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@29.7.0':
@@ -2142,9 +2176,17 @@ packages:
     resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/expect-utils@30.3.0':
+    resolution: {integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/expect@29.7.0':
     resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect@30.3.0':
+    resolution: {integrity: sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/fake-timers@29.7.0':
     resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
@@ -2154,6 +2196,10 @@ packages:
     resolution: {integrity: sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/fake-timers@30.3.0':
+    resolution: {integrity: sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/get-type@30.1.0':
     resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2161,6 +2207,10 @@ packages:
   '@jest/globals@29.7.0':
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/globals@30.3.0':
+    resolution: {integrity: sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/pattern@30.0.1':
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
@@ -2175,6 +2225,15 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/reporters@30.3.0':
+    resolution: {integrity: sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2183,17 +2242,33 @@ packages:
     resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/snapshot-utils@30.3.0':
+    resolution: {integrity: sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/source-map@29.6.3':
     resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/source-map@30.0.1':
+    resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/test-result@29.7.0':
     resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/test-result@30.3.0':
+    resolution: {integrity: sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/test-sequencer@29.7.0':
     resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-sequencer@30.3.0':
+    resolution: {integrity: sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/transform@29.5.0':
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
@@ -2203,12 +2278,20 @@ packages:
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/transform@30.3.0':
+    resolution: {integrity: sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/types@30.2.0':
     resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.3.0':
+    resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -2368,15 +2451,15 @@ packages:
   '@microsoft/api-extractor-model@7.30.5':
     resolution: {integrity: sha512-0ic4rcbcDZHz833RaTZWTGu+NpNgrxVNjVaor0ZDUymfDFzjA/Uuk8hYziIUIOEOSTfmIQqyzVwlzxZxPe7tOA==}
 
-  '@microsoft/api-extractor-model@7.33.5':
-    resolution: {integrity: sha512-Xh4dXuusndVQqVz4nEN9xOp0DyzsKxeD2FFJkSPg4arAjDSKPcy6cAc7CaeBPA7kF2wV1fuDlo2p/bNMpVr8yg==}
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
 
   '@microsoft/api-extractor@7.52.5':
     resolution: {integrity: sha512-6WWgjjg6FkoDWpF/O3sjB05OkszpI5wtKJqd8fUIR/JJUv8IqNCGr1lJUZJnc1HegcT9gAvyf98KfH0wFncU0w==}
     hasBin: true
 
-  '@microsoft/api-extractor@7.58.0':
-    resolution: {integrity: sha512-XcHlDylX5GblbGbs1eBoexjVyvdJMioTPuBCgCorE2rqijzTYxi6eudXyez3xACRxtH9aDtahoL9fYM4XTvQmg==}
+  '@microsoft/api-extractor@7.58.5':
+    resolution: {integrity: sha512-pKQs2MBtGCVcIs1pxkSjhb1GGxYaS3KRCoi7Ki6qCJw6S/zx5ZYvC3CX39RpexBqYcO0asphyrqdW2ifyuSX6A==}
     hasBin: true
 
   '@microsoft/decorators@1.22.2':
@@ -2545,6 +2628,9 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -2647,6 +2733,14 @@ packages:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
@@ -2658,8 +2752,8 @@ packages:
   '@rushstack/debug-certificate-manager@1.6.2':
     resolution: {integrity: sha512-oexPIWsGad5A60yxLYvSGKgXYGMupWuf6DqDus55LHL4UCyY4lO+Roc3UTvWUg/GCeEs6iX6YgIAi79rSxbl6g==}
 
-  '@rushstack/debug-certificate-manager@1.7.10':
-    resolution: {integrity: sha512-qqS7nXT+trdLmG9UKlQzQFxIGv6tKlD+tRtCTrznGkKtx7px3ixS2d/E9aO5zzJD5RA9v6pxDp0RvMafOdUlcA==}
+  '@rushstack/debug-certificate-manager@1.7.16':
+    resolution: {integrity: sha512-LyCMOhWD6YLJgyWgD/sRkwxoLX2PRStyBCBcQSN0qx2w+Gp8WqJAuQaz5BrZgllVjKcS7omBhsEkBt+hIGvKXg==}
 
   '@rushstack/eslint-config@4.5.2':
     resolution: {integrity: sha512-EK5qullXxMevGRwUiJAoVlK6eKCw9JiLunUWzuNsRD53DiIjC6dP6BTSg0D2tzh3uNsV+yOH3mrja+dGwWpiaw==}
@@ -2709,10 +2803,10 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  '@rushstack/heft-api-extractor-plugin@1.3.9':
-    resolution: {integrity: sha512-ZneiG6WGRJARM9IFh+HW87AzXkKP/RMIH5csCDGHxbVRIihCldrNP0i+RkheNEcN2AJtgxGTTKMMnASnxSjtMw==}
+  '@rushstack/heft-api-extractor-plugin@1.3.15':
+    resolution: {integrity: sha512-d3I/+AHBPgusq8kXaiuZCKPOVJHA4y7UrjKbgV7IUrG8fQJYCrEESCpRxirRlwBssv77c+BOLP+JomY/SVVJzg==}
     peerDependencies:
-      '@rushstack/heft': 1.2.9
+      '@rushstack/heft': 1.2.15
 
   '@rushstack/heft-config-file@0.16.8':
     resolution: {integrity: sha512-zmdN2w3XFUjh9ftE5raNiocJCDlqsYdQNu8ldGdyZUqWfpumyC5wHuWHRS72g2+vHOddRMgZ02SNb/HmWI8J0A==}
@@ -2722,8 +2816,8 @@ packages:
     resolution: {integrity: sha512-q2AURE3SHzyaSJznnIF9gdzAnrUQyBBrebtpNKWm6fCN6p319h0Y4Z5JikNANX21/oKvUut6igvak8RQGoQGxA==}
     engines: {node: '>=10.13.0'}
 
-  '@rushstack/heft-config-file@0.20.4':
-    resolution: {integrity: sha512-y/Aua8uwqWKTMlVL+6YrlvISRFIzu5qyAtQo5dBme4/Vf7D3+Q7jb4+sjG8sCJk7Gm1Cn7sZi2dV7LO6YIXgCg==}
+  '@rushstack/heft-config-file@0.20.9':
+    resolution: {integrity: sha512-atd6I956PaMkmplG6zwJaETMD1I1TWoAa8/yC/JTxmVdiineInSFedRl75uQXfOGFE1YLIbGLrZISi3QzMXhpA==}
     engines: {node: '>=10.13.0'}
 
   '@rushstack/heft-dev-cert-plugin@1.0.3':
@@ -2743,13 +2837,16 @@ packages:
       jest-environment-node:
         optional: true
 
-  '@rushstack/heft-jest-plugin@1.2.9':
-    resolution: {integrity: sha512-xmu2R/wJCGrSVY5g5EluIQAB8qmaamB//xYEXFmVrPuuOeHq5G50VoL0Ihi1m61gqgmobBUbh+ZbIeXFqYIQug==}
+  '@rushstack/heft-jest-plugin@2.0.4':
+    resolution: {integrity: sha512-5VyKuk8vnWkM1Z4P8nUAute7gl2Unb/zxOeaW8U28+y2bia2uKKIudCkN/7SuAGGKgs/5IqQ9TGY44OKfywuIw==}
     peerDependencies:
-      '@rushstack/heft': ^1.2.9
-      jest-environment-jsdom: ^29.5.0
-      jest-environment-node: ^29.5.0
+      '@rushstack/heft': ^1.2.15
+      '@types/jest': ^30.0.0
+      jest-environment-jsdom: ^30.3.0
+      jest-environment-node: ^30.3.0
     peerDependenciesMeta:
+      '@types/jest':
+        optional: true
       jest-environment-jsdom:
         optional: true
       jest-environment-node:
@@ -2760,15 +2857,15 @@ packages:
     peerDependencies:
       '@rushstack/heft': 1.1.2
 
-  '@rushstack/heft-lint-plugin@1.2.9':
-    resolution: {integrity: sha512-hLm1GZWgO9yy473vuIz1jMkFA7lFJI0HO31DfLLGv/dzbvy113W/ew11RvBFwpODy75wIdwqnRbg8XNO4O7gCg==}
+  '@rushstack/heft-lint-plugin@1.2.15':
+    resolution: {integrity: sha512-ehmhgCLf1+hAs2Dg/5+9FzFsnqeQUU9Q00FnbU6nlWYXOcPWbMSbL0OU14NCi2TVt6XlkOdSFG5zqrlO73iAlA==}
     peerDependencies:
-      '@rushstack/heft': 1.2.9
+      '@rushstack/heft': 1.2.15
 
-  '@rushstack/heft-node-rig@2.11.29':
-    resolution: {integrity: sha512-3qnlW0quXm2Pi9UgadfeA0PnD05+Pvw7aXrYdv5TYNbENn5gSyjKNXjLlbgDvOWeyjSWI32BopQStffQkPcxww==}
+  '@rushstack/heft-node-rig@2.11.37':
+    resolution: {integrity: sha512-wGZ0H1kKd8kNIgHvnDaW1Bps96MoOLxskHAUhGsvwy+yHbUN7qiaifGquSEIG0mtSb/xX+0yAIqLrL7iApPDVA==}
     peerDependencies:
-      '@rushstack/heft': ^1.2.9
+      '@rushstack/heft': ^1.2.15
 
   '@rushstack/heft-sass-plugin@0.15.24':
     resolution: {integrity: sha512-Psu3KZ6dQdJv2UpROVux1NEfWOFv0dFQVg5wT4N8pppar1m40Y/E7gfxZGgHIeWdXSuwF61d/kKgjxo5qFAiAg==}
@@ -2780,10 +2877,10 @@ packages:
     peerDependencies:
       '@rushstack/heft': 1.1.2
 
-  '@rushstack/heft-typescript-plugin@1.3.4':
-    resolution: {integrity: sha512-y4ebbtjZ6e0j+e6c0t3iTFvkH+ioCRIvV7k3y+fMhALBxiy5+WQExvAkGJQtrCWuYNnjD36YxxjuMIR3diK+5Q==}
+  '@rushstack/heft-typescript-plugin@1.3.10':
+    resolution: {integrity: sha512-h6NeW9ApVo1AiX+RjfDwy3gsgJO7xOFkm8qlxkQ1VZKM0uXXYWcLTN0EK/wn/EaONl0Epsh7V++fo0TgXWIYYw==}
     peerDependencies:
-      '@rushstack/heft': 1.2.9
+      '@rushstack/heft': 1.2.15
 
   '@rushstack/heft-webpack5-plugin@1.2.2':
     resolution: {integrity: sha512-HeHKRcY+EgTHaXqDisSSKcGHbJj1SFnoyXZbbcYLp79xIEkVL+lDDwXvKNiCJG8Ejhhku2Ub4L+ub7XSEko3ug==}
@@ -2791,10 +2888,10 @@ packages:
       '@rushstack/heft': ^1.1.2
       webpack: ^5.82.1
 
-  '@rushstack/heft-webpack5-plugin@1.3.10':
-    resolution: {integrity: sha512-L7DdokBkf/5fq5LZrb/CAOIzT48YdUCb5CAsK34HzcDr4bUzzzZ9vqvQdtwjohD6W/CcrfCqvzTa44rvIXCGRg==}
+  '@rushstack/heft-webpack5-plugin@1.3.16':
+    resolution: {integrity: sha512-bEHJIRW4iI+VU6wXU/kMLeUU6JH1osxuo9uh/dAsDUWUzdC05bUFbn2TudeR4cAjqLW/bsc+qKuoZr2deQDC/g==}
     peerDependencies:
-      '@rushstack/heft': ^1.2.9
+      '@rushstack/heft': ^1.2.15
       webpack: ^5.82.1
 
   '@rushstack/heft@1.1.2':
@@ -2802,8 +2899,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  '@rushstack/heft@1.2.9':
-    resolution: {integrity: sha512-DHDdRcYfW77QRvg3o8MqTYKbX8JAhviv5wDUXIxdpAViyMD89WzFK5E2spNBiKVK1+FZciRX4cpOBIXe9sij/w==}
+  '@rushstack/heft@1.2.15':
+    resolution: {integrity: sha512-8Yf9zOLDiWZ0o5StZoxX88cIiMJykG02uRHNWlquYC/dtlc4wo8nXdhNCq6Kj/SDU5AfYYuPWNRjYus/QebUgw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -2837,8 +2934,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/node-core-library@5.21.0':
-    resolution: {integrity: sha512-LFzN+1lyWROit/P8Md6yxAth7lLYKn37oCKJHirEE2TQB25NDUM7bALf0ar+JAtwFfRCH+D+DGOA7DAzIi2r+g==}
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -2853,8 +2950,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/operation-graph@0.6.4':
-    resolution: {integrity: sha512-JtSmRRUHvKxOskGFca8PyTxZIz2dJT9n//h9ZiI70X6GSDvNAKLSaYMMw/h9of81FO/gZgQUUbCfuh3k4zwoVw==}
+  '@rushstack/operation-graph@0.6.8':
+    resolution: {integrity: sha512-BRQUPuu8RMI8hJl5nqUaugA3S3oJj31WCQ94Ewn8BMnnV+d9n3cmKxeC8nBU3oyjjmtuvem5WyKzozn+bYDixg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -2883,8 +2980,8 @@ packages:
   '@rushstack/rig-package@0.6.0':
     resolution: {integrity: sha512-ZQmfzsLE2+Y91GF15c65L/slMRVhF6Hycq04D4TwtdGaUAbIXXg9c5pKA5KFU7M4QMaihoobp9JJYpYcaY3zOw==}
 
-  '@rushstack/rig-package@0.7.2':
-    resolution: {integrity: sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==}
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
 
   '@rushstack/set-webpack-public-path-plugin@5.2.2':
     resolution: {integrity: sha512-UV3UsWdsBhyHIvB5XeDmDBZLqYTwgsQfeuNvpriOnfAaxEmA3c0N2RW1uShzBtNw8Iuddzg7vFADuTJLfWf+Qw==}
@@ -2911,8 +3008,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/terminal@0.22.4':
-    resolution: {integrity: sha512-fhtLjnXCc/4WleVbVl6aoc7jcWnU6yqjS1S8WoaNREG3ycu/viZ9R/9QM7Y/b4CDvcXoiDyMNIay7JMwBptM3g==}
+  '@rushstack/terminal@0.23.0':
+    resolution: {integrity: sha512-7FfI9irLqnBDxCvMEXdEXLDjaouZsGbKkeGfmW8IOn8aYi7DV9aaXaEQHCcVxWMvEDOkuTf4y6RMDgIY5CFuUQ==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -2931,8 +3028,8 @@ packages:
   '@rushstack/ts-command-line@5.1.2':
     resolution: {integrity: sha512-jn0EnSefYrkZDrBGd6KGuecL84LI06DgzL4hVQ46AUijNBt2nRU/ST4HhrfII/w91siCd1J/Okvxq/BS75Me/A==}
 
-  '@rushstack/ts-command-line@5.3.4':
-    resolution: {integrity: sha512-MLkVKVEN6/2clKTrjN2B2KqKCuPxRwnNsWY7a+FCAq2EMdkj10cM8YgiBSMeGFfzM0mDMzargpHNnNzaBi9Whg==}
+  '@rushstack/ts-command-line@5.3.8':
+    resolution: {integrity: sha512-vKL4fVR2TdnMdCmlP71nZUzbNANOYlR7NfN+J/YL9UIvicDIEB+ZtH38LcJECOZUwHia8C5Mg98kc4kPt/ev5w==}
 
   '@rushstack/typings-generator@0.14.30':
     resolution: {integrity: sha512-0hqTrvDa7NXxdTzLwPUQ044s8nRzDu8tQxCpIJnO2C+msrsfW2LDIBtqCijShgbU2fj7atSbbh6CtytCm6otOw==}
@@ -2961,8 +3058,8 @@ packages:
       webpack:
         optional: true
 
-  '@rushstack/webpack-preserve-dynamic-require-plugin@0.12.10':
-    resolution: {integrity: sha512-tgM4WoFzjHazCcaqlbKHRRSLqZ8BcDIB1UIFrM80gtf9pOOYCuZCohptRKujixGYtarc0vywXoTNQV2lloXbKw==}
+  '@rushstack/webpack-preserve-dynamic-require-plugin@0.12.16':
+    resolution: {integrity: sha512-8k6Ji2v9K2uDMSLA+BRlCxqqF6UKDynpAcPyRnInegoxVNLUcNSTi2W7dfsTtSBkmd6pcC02s2L1822MNkxveA==}
     engines: {node: '>=10.17.1'}
 
   '@rushstack/webpack5-localization-plugin@0.15.2':
@@ -3012,12 +3109,18 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@sinonjs/fake-timers@15.3.2':
+    resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
+
   '@swc/helpers@0.5.19':
     resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
@@ -3075,9 +3178,6 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
-
-  '@types/heft-jest@1.0.1':
-    resolution: {integrity: sha512-cF2iEUpvGh2WgLowHVAdjI05xuDo+GwCA8hGV3Q5PBl8apjd6BTcpPFQ2uPlfUM7BLpgur2xpYo8VeBXopMI4A==}
 
   '@types/heft-jest@1.0.2':
     resolution: {integrity: sha512-HabX0JO8Pk+a3gTm2DQwTMrfZjqP6VxDnn8kIXAP6uZbmy4bkKuFRi9T9BV9K6LhwHrmcgq5kk2YikYHy4LJeg==}
@@ -3398,6 +3498,101 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -3560,6 +3755,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -3567,6 +3766,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -3668,13 +3871,27 @@ packages:
     peerDependencies:
       '@babel/core': ^7.8.0
 
+  babel-jest@30.3.0:
+    resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0 || ^8.0.0-0
+
   babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
 
+  babel-plugin-istanbul@7.0.1:
+    resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
+    engines: {node: '>=12'}
+
   babel-plugin-jest-hoist@29.6.3:
     resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  babel-plugin-jest-hoist@30.3.0:
+    resolution: {integrity: sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   babel-preset-current-node-syntax@1.2.0:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
@@ -3686,6 +3903,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  babel-preset-jest@30.3.0:
+    resolution: {integrity: sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0 || ^8.0.0-beta.1
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -3836,6 +4059,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
@@ -4156,6 +4382,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   editions@6.22.0:
     resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
     engines: {ecmascript: '>= es5', node: '>=4'}
@@ -4190,6 +4419,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -4423,6 +4655,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  exit-x@0.2.2:
+    resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
+    engines: {node: '>= 0.8.0'}
+
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -4433,6 +4669,10 @@ packages:
 
   expect@30.2.0:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  expect@30.3.0:
+    resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   express@4.22.1:
@@ -4546,6 +4786,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -4634,6 +4878,11 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -5013,12 +5262,20 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
   istanbul-lib-source-maps@4.0.1:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -5029,6 +5286,9 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
@@ -5038,9 +5298,17 @@ packages:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-changed-files@30.3.0:
+    resolution: {integrity: sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-circus@29.7.0:
     resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-circus@30.3.0:
+    resolution: {integrity: sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-config@29.5.0:
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
@@ -5054,6 +5322,21 @@ packages:
       ts-node:
         optional: true
 
+  jest-config@30.3.0:
+    resolution: {integrity: sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      esbuild-register: '>=3.4.0'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild-register:
+        optional: true
+      ts-node:
+        optional: true
+
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5062,13 +5345,25 @@ packages:
     resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-diff@30.3.0:
+    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-docblock@29.7.0:
     resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-docblock@30.2.0:
+    resolution: {integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-each@29.7.0:
     resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-each@30.3.0:
+    resolution: {integrity: sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-environment-jsdom@29.5.0:
     resolution: {integrity: sha512-/KG8yEK4aN8ak56yFVdqFDzKNHgF4BAymCx2LbPNPsUshUlfAl0eX402Xm1pt+eoG9SLZEUVifqXtX8SK74KCw==}
@@ -5091,6 +5386,10 @@ packages:
     resolution: {integrity: sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-environment-node@30.3.0:
+    resolution: {integrity: sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5098,6 +5397,10 @@ packages:
   jest-haste-map@29.7.0:
     resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-haste-map@30.3.0:
+    resolution: {integrity: sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-junit@12.3.0:
     resolution: {integrity: sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==}
@@ -5107,12 +5410,20 @@ packages:
     resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-leak-detector@30.3.0:
+    resolution: {integrity: sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-matcher-utils@30.2.0:
     resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@30.3.0:
+    resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-message-util@29.7.0:
@@ -5123,12 +5434,20 @@ packages:
     resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-message-util@30.3.0:
+    resolution: {integrity: sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-mock@30.2.0:
     resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.3.0:
+    resolution: {integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
@@ -5152,6 +5471,10 @@ packages:
     resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-resolve-dependencies@30.3.0:
+    resolution: {integrity: sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-resolve@29.5.0:
     resolution: {integrity: sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5160,13 +5483,25 @@ packages:
     resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-resolve@30.3.0:
+    resolution: {integrity: sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-runner@29.7.0:
     resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-runner@30.3.0:
+    resolution: {integrity: sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-runtime@29.7.0:
     resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runtime@30.3.0:
+    resolution: {integrity: sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-snapshot@29.5.0:
     resolution: {integrity: sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==}
@@ -5176,12 +5511,20 @@ packages:
     resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-snapshot@30.3.0:
+    resolution: {integrity: sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-util@30.2.0:
     resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-util@30.3.0:
+    resolution: {integrity: sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-validate@29.7.0:
@@ -5192,9 +5535,17 @@ packages:
     resolution: {integrity: sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-validate@30.3.0:
+    resolution: {integrity: sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-watcher@29.7.0:
     resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-watcher@30.3.0:
+    resolution: {integrity: sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -5203,6 +5554,10 @@ packages:
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-worker@30.3.0:
+    resolution: {integrity: sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
@@ -5362,6 +5717,9 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -5482,6 +5840,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -5504,6 +5866,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -5657,6 +6024,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -5701,6 +6071,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -5953,6 +6327,10 @@ packages:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  pretty-format@30.3.0:
+    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -5975,6 +6353,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@7.0.1:
+    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -6367,6 +6748,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -6459,6 +6844,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -6491,6 +6880,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom-buf@3.0.1:
     resolution: {integrity: sha512-iJaWw2WroigLHzQysdc5WWeUc99p7ea7AEgB6JkY8CMyiO1yTVAA1gIlJJgORElUIR+lcZJkNl1OGChMhvc2Cw==}
@@ -6547,6 +6940,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   tabster@8.7.0:
     resolution: {integrity: sha512-AKYquti8AdWzuqJdQo4LUMQDZrHoYQy6V+8yUq2PmgLZV10EaB+8BD0nWOfC/3TBp4mPNg4fbHkz6SFtkr0PpA==}
@@ -6757,6 +7154,9 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -6946,12 +7346,24 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -7295,6 +7707,22 @@ snapshots:
     optional: true
 
   '@ctrl/tinycolor@3.6.1': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/hash@0.9.2': {}
 
@@ -8743,6 +9171,15 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -8760,6 +9197,15 @@ snapshots:
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+      slash: 3.0.0
+
+  '@jest/console@30.3.0':
+    dependencies:
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      chalk: 4.1.2
+      jest-message-util: 30.3.0
+      jest-util: 30.3.0
       slash: 3.0.0
 
   '@jest/core@29.5.0':
@@ -8797,7 +9243,44 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@30.3.0':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@22.19.13)
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   '@jest/diff-sequences@30.0.1': {}
+
+  '@jest/diff-sequences@30.3.0': {}
 
   '@jest/environment@29.7.0':
     dependencies:
@@ -8813,6 +9296,13 @@ snapshots:
       '@types/node': 22.19.13
       jest-mock: 30.2.0
 
+  '@jest/environment@30.3.0':
+    dependencies:
+      '@jest/fake-timers': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      jest-mock: 30.3.0
+
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
@@ -8821,10 +9311,21 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
+  '@jest/expect-utils@30.3.0':
+    dependencies:
+      '@jest/get-type': 30.1.0
+
   '@jest/expect@29.7.0':
     dependencies:
       expect: 29.7.0
       jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/expect@30.3.0':
+    dependencies:
+      expect: 30.3.0
+      jest-snapshot: 30.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8846,6 +9347,15 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
 
+  '@jest/fake-timers@30.3.0':
+    dependencies:
+      '@jest/types': 30.3.0
+      '@sinonjs/fake-timers': 15.3.2
+      '@types/node': 22.19.13
+      jest-message-util: 30.3.0
+      jest-mock: 30.3.0
+      jest-util: 30.3.0
+
   '@jest/get-type@30.1.0': {}
 
   '@jest/globals@29.7.0':
@@ -8854,6 +9364,15 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/globals@30.3.0':
+    dependencies:
+      '@jest/environment': 30.3.0
+      '@jest/expect': 30.3.0
+      '@jest/types': 30.3.0
+      jest-mock: 30.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8891,6 +9410,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@jest/reporters@30.3.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 22.19.13
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit-x: 0.2.2
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      jest-message-util: 30.3.0
+      jest-util: 30.3.0
+      jest-worker: 30.3.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
@@ -8899,7 +9446,20 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.48
 
+  '@jest/snapshot-utils@30.3.0':
+    dependencies:
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      natural-compare: 1.4.0
+
   '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/source-map@30.0.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       callsites: 3.1.0
@@ -8912,11 +9472,25 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
+  '@jest/test-result@30.3.0':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
   '@jest/test-sequencer@29.7.0':
     dependencies:
       '@jest/test-result': 29.7.0
       graceful-fs: 4.2.11
       jest-haste-map: 29.7.0
+      slash: 3.0.0
+
+  '@jest/test-sequencer@30.3.0':
+    dependencies:
+      '@jest/test-result': 30.3.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.3.0
       slash: 3.0.0
 
   '@jest/transform@29.5.0':
@@ -8959,6 +9533,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@jest/transform@30.3.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/types': 30.3.0
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 7.0.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-util: 30.3.0
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@jest/types@29.6.3':
     dependencies:
       '@jest/schemas': 29.6.3
@@ -8969,6 +9562,16 @@ snapshots:
       chalk: 4.1.2
 
   '@jest/types@30.2.0':
+    dependencies:
+      '@jest/pattern': 30.0.1
+      '@jest/schemas': 30.0.5
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 22.19.13
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jest/types@30.3.0':
     dependencies:
       '@jest/pattern': 30.0.1
       '@jest/schemas': 30.0.5
@@ -9147,11 +9750,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.33.5(@types/node@22.19.13)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@22.19.13)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -9173,20 +9776,19 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.0(@types/node@22.19.13)':
+  '@microsoft/api-extractor@7.58.5(@types/node@22.19.13)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.5(@types/node@22.19.13)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@22.19.13)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
-      '@rushstack/ts-command-line': 5.3.4(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
+      '@rushstack/ts-command-line': 5.3.8(@types/node@22.19.13)
       diff: 8.0.3
-      lodash: 4.17.23
       minimatch: 10.2.3
       resolve: 1.22.11
-      semver: 7.5.4
+      semver: 7.7.4
       source-map: 0.6.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9770,12 +10372,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@microsoft/spfx-heft-plugins@1.22.2(patch_hash=185ffebb2de7b1fb5f6ad4d92e9d8ad3b2d3207721e8db14e7ac1f3d716d0b1a)(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)':
+  '@microsoft/spfx-heft-plugins@1.22.2(patch_hash=185ffebb2de7b1fb5f6ad4d92e9d8ad3b2d3207721e8db14e7ac1f3d716d0b1a)(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)':
     dependencies:
       '@azure/storage-blob': 12.26.0
       '@microsoft/sp-css-loader': 1.22.2(@types/node@22.19.13)(webpack@5.95.0)
       '@microsoft/sp-module-interfaces': 1.22.2(@types/node@22.19.13)
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
       '@rushstack/heft-config-file': 0.19.2(@types/node@22.19.13)
       '@rushstack/localization-utilities': 0.14.2(@types/node@22.19.13)
       '@rushstack/module-minifier': 0.8.2(@types/node@22.19.13)
@@ -9877,6 +10479,13 @@ snapshots:
   '@microsoft/tsdoc@0.15.1': {}
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@noble/hashes@1.4.0': {}
 
@@ -10045,6 +10654,11 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@pkgr/core@0.2.9': {}
+
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     optional: true
 
@@ -10058,10 +10672,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/debug-certificate-manager@1.7.10(@types/node@22.19.13)':
+  '@rushstack/debug-certificate-manager@1.7.16(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
       node-forge: 1.4.0
     transitivePeerDependencies:
       - '@types/node'
@@ -10205,11 +10819,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rushstack/heft-api-extractor-plugin@1.3.9(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)':
+  '@rushstack/heft-api-extractor-plugin@1.3.15(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      semver: 7.5.4
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      semver: 7.7.4
     transitivePeerDependencies:
       - '@types/node'
 
@@ -10232,12 +10846,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-config-file@0.20.4(@types/node@22.19.13)':
+  '@rushstack/heft-config-file@0.20.9(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
-      '@ungap/structured-clone': 1.3.0
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
       jsonpath-plus: 10.3.0
     transitivePeerDependencies:
       - '@types/node'
@@ -10273,26 +10886,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@rushstack/heft-jest-plugin@1.2.9(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)':
+  '@rushstack/heft-jest-plugin@2.0.4(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/jest@30.0.0)(@types/node@22.19.13)(jest-environment-node@30.3.0)':
     dependencies:
-      '@jest/core': 29.5.0
-      '@jest/reporters': 29.5.0
-      '@jest/transform': 29.5.0
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
-      '@rushstack/heft-config-file': 0.20.4(@types/node@22.19.13)
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
-      jest-config: 29.5.0(@types/node@22.19.13)
-      jest-resolve: 29.5.0
-      jest-snapshot: 29.5.0
-      lodash: 4.17.23
-      punycode: 2.3.1
+      '@jest/core': 30.3.0
+      '@jest/reporters': 30.3.0
+      '@jest/transform': 30.3.0
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
+      '@rushstack/heft-config-file': 0.20.9(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
+      jest-config: 30.3.0(@types/node@22.19.13)
+      jest-resolve: 30.3.0
+      jest-snapshot: 30.3.0
     optionalDependencies:
-      jest-environment-jsdom: 29.5.0
-      jest-environment-node: 29.5.0
+      '@types/jest': 30.0.0
+      jest-environment-node: 30.3.0
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
+      - esbuild-register
       - node-notifier
       - supports-color
       - ts-node
@@ -10306,31 +10918,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-lint-plugin@1.2.9(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)':
+  '@rushstack/heft-lint-plugin@1.2.15(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
       json-stable-stringify-without-jsonify: 1.0.1
-      semver: 7.5.4
+      semver: 7.7.4
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-node-rig@2.11.29(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)(jest-environment-jsdom@29.5.0)':
+  '@rushstack/heft-node-rig@2.11.37(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)':
     dependencies:
-      '@microsoft/api-extractor': 7.58.0(@types/node@22.19.13)
+      '@microsoft/api-extractor': 7.58.5(@types/node@22.19.13)
       '@rushstack/eslint-config': 4.6.4(eslint@9.37.0)(typescript@5.8.3)
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
-      '@rushstack/heft-api-extractor-plugin': 1.3.9(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)
-      '@rushstack/heft-jest-plugin': 1.2.9(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
-      '@rushstack/heft-lint-plugin': 1.2.9(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)
-      '@rushstack/heft-typescript-plugin': 1.3.4(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)
-      '@types/heft-jest': 1.0.1
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
+      '@rushstack/heft-api-extractor-plugin': 1.3.15(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)
+      '@rushstack/heft-jest-plugin': 2.0.4(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/jest@30.0.0)(@types/node@22.19.13)(jest-environment-node@30.3.0)
+      '@rushstack/heft-lint-plugin': 1.2.15(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)
+      '@rushstack/heft-typescript-plugin': 1.3.10(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)
+      '@types/jest': 30.0.0
       eslint: 9.37.0
-      jest-environment-node: 29.5.0
+      jest-environment-node: 30.3.0
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
+      - esbuild-register
       - jest-environment-jsdom
       - jiti
       - node-notifier
@@ -10360,13 +10973,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-typescript-plugin@1.3.4(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)':
+  '@rushstack/heft-typescript-plugin@1.3.10(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
-      '@rushstack/heft-config-file': 0.20.4(@types/node@22.19.13)
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
+      '@rushstack/heft-config-file': 0.20.9(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
       '@types/tapable': 1.0.6
-      semver: 7.5.4
+      semver: 7.7.4
       tapable: 1.1.3
     transitivePeerDependencies:
       - '@types/node'
@@ -10390,11 +11003,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@rushstack/heft-webpack5-plugin@1.3.10(@rushstack/heft@1.2.9(@types/node@22.19.13))(@types/node@22.19.13)(webpack@5.105.4)':
+  '@rushstack/heft-webpack5-plugin@1.3.16(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)(webpack@5.105.4)':
     dependencies:
-      '@rushstack/debug-certificate-manager': 1.7.10(@types/node@22.19.13)
-      '@rushstack/heft': 1.2.9(@types/node@22.19.13)
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
+      '@rushstack/debug-certificate-manager': 1.7.16(@types/node@22.19.13)
+      '@rushstack/heft': 1.2.15(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
       '@types/tapable': 1.0.6
       tapable: 1.1.3
       watchpack: 2.4.0
@@ -10426,14 +11039,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft@1.2.9(@types/node@22.19.13)':
+  '@rushstack/heft@1.2.15(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/heft-config-file': 0.20.4(@types/node@22.19.13)
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      '@rushstack/operation-graph': 0.6.4(@types/node@22.19.13)
-      '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
-      '@rushstack/ts-command-line': 5.3.4(@types/node@22.19.13)
+      '@rushstack/heft-config-file': 0.20.9(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      '@rushstack/operation-graph': 0.6.8(@types/node@22.19.13)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
+      '@rushstack/ts-command-line': 5.3.8(@types/node@22.19.13)
       '@types/tapable': 1.0.6
       fast-glob: 3.3.3
       git-repo-info: 2.1.1
@@ -10492,7 +11105,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
 
-  '@rushstack/node-core-library@5.21.0(@types/node@22.19.13)':
+  '@rushstack/node-core-library@5.23.1(@types/node@22.19.13)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -10501,7 +11114,7 @@ snapshots:
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.11
-      semver: 7.5.4
+      semver: 7.7.4
     optionalDependencies:
       '@types/node': 22.19.13
 
@@ -10512,10 +11125,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
 
-  '@rushstack/operation-graph@0.6.4(@types/node@22.19.13)':
+  '@rushstack/operation-graph@0.6.8(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
     optionalDependencies:
       '@types/node': 22.19.13
 
@@ -10537,10 +11150,10 @@ snapshots:
       resolve: 1.22.11
       strip-json-comments: 3.1.1
 
-  '@rushstack/rig-package@0.7.2':
+  '@rushstack/rig-package@0.7.3':
     dependencies:
+      jju: 1.4.0
       resolve: 1.22.11
-      strip-json-comments: 3.1.1
 
   '@rushstack/set-webpack-public-path-plugin@5.2.2(@types/node@22.19.13)(webpack@5.95.0)':
     dependencies:
@@ -10567,9 +11180,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
 
-  '@rushstack/terminal@0.22.4(@types/node@22.19.13)':
+  '@rushstack/terminal@0.23.0(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/node-core-library': 5.21.0(@types/node@22.19.13)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.13)
       '@rushstack/problem-matcher': 0.2.1(@types/node@22.19.13)
       supports-color: 8.1.1
     optionalDependencies:
@@ -10597,9 +11210,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@5.3.4(@types/node@22.19.13)':
+  '@rushstack/ts-command-line@5.3.8(@types/node@22.19.13)':
     dependencies:
-      '@rushstack/terminal': 0.22.4(@types/node@22.19.13)
+      '@rushstack/terminal': 0.23.0(@types/node@22.19.13)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -10631,7 +11244,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.95.0
 
-  '@rushstack/webpack-preserve-dynamic-require-plugin@0.12.10': {}
+  '@rushstack/webpack-preserve-dynamic-require-plugin@0.12.16': {}
 
   '@rushstack/webpack5-localization-plugin@0.15.2(@types/node@22.19.13)(webpack@5.95.0)':
     dependencies:
@@ -10675,11 +11288,20 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sinonjs/fake-timers@15.3.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
   '@swc/helpers@0.5.19':
     dependencies:
       tslib: 2.8.1
 
   '@tootallnate/once@2.0.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/adm-zip@0.5.7':
     dependencies:
@@ -10761,10 +11383,6 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.19.13
-
-  '@types/heft-jest@1.0.1':
-    dependencies:
-      '@types/jest': 30.0.0
 
   '@types/heft-jest@1.0.2':
     dependencies:
@@ -11257,6 +11875,65 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -11444,11 +12121,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -11581,6 +12262,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@30.3.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.3.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.28.6
@@ -11591,12 +12285,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-istanbul@7.0.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 6.0.3
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
+
+  babel-plugin-jest-hoist@30.3.0:
+    dependencies:
+      '@types/babel__core': 7.20.5
 
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
     dependencies:
@@ -11621,6 +12329,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+
+  babel-preset-jest@30.3.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      babel-plugin-jest-hoist: 30.3.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
   balanced-match@1.0.2: {}
@@ -11771,6 +12485,8 @@ snapshots:
   ci-info@4.4.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   clean-css@5.3.3:
     dependencies:
@@ -12088,6 +12804,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   editions@6.22.0:
     dependencies:
       version-range: 4.15.0
@@ -12113,6 +12831,8 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
 
@@ -12550,6 +13270,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  exit-x@0.2.2: {}
+
   exit@0.1.2: {}
 
   expect@29.7.0:
@@ -12568,6 +13290,15 @@ snapshots:
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
+
+  expect@30.3.0:
+    dependencies:
+      '@jest/expect-utils': 30.3.0
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.3.0
+      jest-message-util: 30.3.0
+      jest-mock: 30.3.0
+      jest-util: 30.3.0
 
   express@4.22.1:
     dependencies:
@@ -12711,6 +13442,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -12800,6 +13536,15 @@ snapshots:
       tslib: 2.3.1
 
   glob-to-regexp@0.4.1: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -13187,6 +13932,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
@@ -13198,6 +13953,14 @@ snapshots:
       debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13215,6 +13978,12 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -13225,6 +13994,12 @@ snapshots:
     dependencies:
       execa: 5.1.1
       jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-changed-files@30.3.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 30.3.0
       p-limit: 3.1.0
 
   jest-circus@29.7.0:
@@ -13247,6 +14022,32 @@ snapshots:
       p-limit: 3.1.0
       pretty-format: 29.7.0
       pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-circus@30.3.0:
+    dependencies:
+      '@jest/environment': 30.3.0
+      '@jest/expect': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2
+      is-generator-fn: 2.1.0
+      jest-each: 30.3.0
+      jest-matcher-utils: 30.3.0
+      jest-message-util: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      p-limit: 3.1.0
+      pretty-format: 30.3.0
+      pure-rand: 7.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
     transitivePeerDependencies:
@@ -13283,6 +14084,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.3.0(@types/node@22.19.13):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.13
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -13297,7 +14129,18 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.2.0
 
+  jest-diff@30.3.0:
+    dependencies:
+      '@jest/diff-sequences': 30.3.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.3.0
+
   jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-docblock@30.2.0:
     dependencies:
       detect-newline: 3.1.0
 
@@ -13308,6 +14151,14 @@ snapshots:
       jest-get-type: 29.6.3
       jest-util: 29.7.0
       pretty-format: 29.7.0
+
+  jest-each@30.3.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      jest-util: 30.3.0
+      pretty-format: 30.3.0
 
   jest-environment-jsdom@29.5.0:
     dependencies:
@@ -13352,6 +14203,16 @@ snapshots:
       jest-util: 30.2.0
       jest-validate: 30.2.0
 
+  jest-environment-node@30.3.0:
+    dependencies:
+      '@jest/environment': 30.3.0
+      '@jest/fake-timers': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      jest-mock: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+
   jest-get-type@29.6.3: {}
 
   jest-haste-map@29.7.0:
@@ -13370,6 +14231,21 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  jest-haste-map@30.3.0:
+    dependencies:
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 30.0.1
+      jest-util: 30.3.0
+      jest-worker: 30.3.0
+      picomatch: 4.0.3
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
   jest-junit@12.3.0:
     dependencies:
       mkdirp: 1.0.4
@@ -13381,6 +14257,11 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
+
+  jest-leak-detector@30.3.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      pretty-format: 30.3.0
 
   jest-matcher-utils@29.7.0:
     dependencies:
@@ -13395,6 +14276,13 @@ snapshots:
       chalk: 4.1.2
       jest-diff: 30.2.0
       pretty-format: 30.2.0
+
+  jest-matcher-utils@30.3.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.3.0
+      pretty-format: 30.3.0
 
   jest-message-util@29.7.0:
     dependencies:
@@ -13420,6 +14308,18 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-message-util@30.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@jest/types': 30.3.0
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      picomatch: 4.0.3
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -13432,6 +14332,12 @@ snapshots:
       '@types/node': 22.19.13
       jest-util: 30.2.0
 
+  jest-mock@30.3.0:
+    dependencies:
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      jest-util: 30.3.0
+
   jest-pnp-resolver@1.2.3(jest-resolve@29.5.0):
     optionalDependencies:
       jest-resolve: 29.5.0
@@ -13439,6 +14345,10 @@ snapshots:
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
     optionalDependencies:
       jest-resolve: 29.7.0
+
+  jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
+    optionalDependencies:
+      jest-resolve: 30.3.0
 
   jest-regex-util@29.6.3: {}
 
@@ -13448,6 +14358,13 @@ snapshots:
     dependencies:
       jest-regex-util: 29.6.3
       jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve-dependencies@30.3.0:
+    dependencies:
+      jest-regex-util: 30.0.1
+      jest-snapshot: 30.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13475,6 +14392,17 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
+  jest-resolve@30.3.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.3.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.3.0)
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      slash: 3.0.0
+      unrs-resolver: 1.11.1
+
   jest-runner@29.7.0:
     dependencies:
       '@jest/console': 29.7.0
@@ -13496,6 +14424,33 @@ snapshots:
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runner@30.3.0:
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/environment': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      chalk: 4.1.2
+      emittery: 0.13.1
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-haste-map: 30.3.0
+      jest-leak-detector: 30.3.0
+      jest-message-util: 30.3.0
+      jest-resolve: 30.3.0
+      jest-runtime: 30.3.0
+      jest-util: 30.3.0
+      jest-watcher: 30.3.0
+      jest-worker: 30.3.0
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
@@ -13523,6 +14478,33 @@ snapshots:
       jest-resolve: 29.7.0
       jest-snapshot: 29.7.0
       jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@30.3.0:
+    dependencies:
+      '@jest/environment': 30.3.0
+      '@jest/fake-timers': 30.3.0
+      '@jest/globals': 30.3.0
+      '@jest/source-map': 30.0.1
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      chalk: 4.1.2
+      cjs-module-lexer: 2.2.0
+      collect-v8-coverage: 1.0.3
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-mock: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -13581,6 +14563,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jest-snapshot@30.3.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      '@jest/expect-utils': 30.3.0
+      '@jest/get-type': 30.1.0
+      '@jest/snapshot-utils': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      expect: 30.3.0
+      graceful-fs: 4.2.11
+      jest-diff: 30.3.0
+      jest-matcher-utils: 30.3.0
+      jest-message-util: 30.3.0
+      jest-util: 30.3.0
+      pretty-format: 30.3.0
+      semver: 7.7.4
+      synckit: 0.11.12
+    transitivePeerDependencies:
+      - supports-color
+
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -13593,6 +14601,15 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
+      '@types/node': 22.19.13
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.3
+
+  jest-util@30.3.0:
+    dependencies:
+      '@jest/types': 30.3.0
       '@types/node': 22.19.13
       chalk: 4.1.2
       ci-info: 4.4.0
@@ -13617,6 +14634,15 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.2.0
 
+  jest-validate@30.3.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.3.0
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      leven: 3.1.0
+      pretty-format: 30.3.0
+
   jest-watcher@29.7.0:
     dependencies:
       '@jest/test-result': 29.7.0
@@ -13626,6 +14652,17 @@ snapshots:
       chalk: 4.1.2
       emittery: 0.13.1
       jest-util: 29.7.0
+      string-length: 4.0.2
+
+  jest-watcher@30.3.0:
+    dependencies:
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 22.19.13
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 30.3.0
       string-length: 4.0.2
 
   jest-worker@27.5.1:
@@ -13638,6 +14675,14 @@ snapshots:
     dependencies:
       '@types/node': 22.19.13
       jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest-worker@30.3.0:
+    dependencies:
+      '@types/node': 22.19.13
+      '@ungap/structured-clone': 1.3.0
+      jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13805,6 +14850,8 @@ snapshots:
     dependencies:
       tslib: 2.3.1
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -13940,6 +14987,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   mkdirp@1.0.4: {}
 
   ms@2.0.0: {}
@@ -13958,6 +15007,8 @@ snapshots:
       minimatch: 9.0.9
 
   nanoid@3.3.11: {}
+
+  napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
 
@@ -14111,6 +15162,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   pako@1.0.11: {}
 
   param-case@3.0.4:
@@ -14153,6 +15206,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -14417,6 +15475,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  pretty-format@30.3.0:
+    dependencies:
+      '@jest/schemas': 30.0.5
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   process-nextick-args@2.0.1: {}
 
   prop-types@15.8.1:
@@ -14441,6 +15505,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@7.0.1: {}
 
   pvtsutils@1.3.6:
     dependencies:
@@ -14835,6 +15901,8 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  signal-exit@4.1.0: {}
+
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -14938,6 +16006,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -14998,6 +16072,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-bom-buf@3.0.1:
     dependencies:
       is-utf8: 0.2.1
@@ -15046,6 +16124,10 @@ snapshots:
       stable: 0.1.8
 
   symbol-tree@3.2.4: {}
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   tabster@8.7.0:
     dependencies:
@@ -15251,6 +16333,30 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -15587,12 +16693,29 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   write-file-atomic@4.0.2:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
 
   ws@8.19.0: {}
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -132,16 +132,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -181,16 +181,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -230,16 +230,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -279,16 +279,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -328,16 +328,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -380,16 +380,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -429,16 +429,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -478,16 +478,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -536,16 +536,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/react':
         specifier: 17.0.45
         version: 17.0.45
@@ -603,16 +603,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -667,16 +667,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/react':
         specifier: 17.0.45
         version: 17.0.45
@@ -731,16 +731,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -780,16 +780,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -820,16 +820,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -878,16 +878,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -936,16 +936,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/webpack-env':
         specifier: ~1.15.2
         version: 1.15.3
@@ -1003,16 +1003,16 @@ importers:
         version: 1.22.2(@types/node@22.19.13)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.22.2
-        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)
+        version: 1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)
       '@rushstack/eslint-config':
         specifier: 4.6.4
         version: 4.6.4(eslint@8.57.1)(typescript@5.8.3)
       '@rushstack/heft':
         specifier: ^1.2.15
         version: 1.2.15(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/react':
         specifier: 17.0.45
         version: 17.0.45
@@ -1123,9 +1123,9 @@ importers:
       '@rushstack/heft-node-rig':
         specifier: ^2.11.37
         version: 2.11.37(@rushstack/heft@1.2.15(@types/node@22.19.13))(@types/node@22.19.13)
-      '@types/heft-jest':
-        specifier: ^1.0.6
-        version: 1.0.6
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^22.18.6
         version: 22.19.13
@@ -2148,10 +2148,6 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/diff-sequences@30.0.1':
-    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/diff-sequences@30.3.0':
     resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2171,10 +2167,6 @@ packages:
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jest/expect-utils@30.2.0':
-    resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@30.3.0':
     resolution: {integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==}
@@ -3181,9 +3173,6 @@ packages:
 
   '@types/heft-jest@1.0.2':
     resolution: {integrity: sha512-HabX0JO8Pk+a3gTm2DQwTMrfZjqP6VxDnn8kIXAP6uZbmy4bkKuFRi9T9BV9K6LhwHrmcgq5kk2YikYHy4LJeg==}
-
-  '@types/heft-jest@1.0.6':
-    resolution: {integrity: sha512-oTVSfKEgvQEaukVq+y57m5UTo2sSh3MxmJWxpcnASPjSi3RUKbKXeNjvmrSnT4D6rF3Cs57u2jfn9JFFKf2hLg==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -4667,10 +4656,6 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  expect@30.2.0:
-    resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -5341,10 +5326,6 @@ packages:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-diff@30.2.0:
-    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-diff@30.3.0:
     resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -5417,10 +5398,6 @@ packages:
   jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-matcher-utils@30.2.0:
-    resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-matcher-utils@30.3.0:
     resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
@@ -5761,8 +5738,6 @@ packages:
 
   memfs@4.56.11:
     resolution: {integrity: sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==}
-    peerDependencies:
-      tslib: '2'
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -9278,8 +9253,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/diff-sequences@30.0.1': {}
-
   '@jest/diff-sequences@30.3.0': {}
 
   '@jest/environment@29.7.0':
@@ -9306,10 +9279,6 @@ snapshots:
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
-
-  '@jest/expect-utils@30.2.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
 
   '@jest/expect-utils@30.3.0':
     dependencies:
@@ -10417,7 +10386,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@microsoft/spfx-web-build-rig@1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)(tslib@2.3.1)':
+  '@microsoft/spfx-web-build-rig@1.22.2(@types/node@22.19.13)(jest-environment-node@29.7.0)':
     dependencies:
       '@microsoft/api-extractor': 7.52.5(@types/node@22.19.13)
       '@microsoft/spfx-heft-plugins': 1.22.2(patch_hash=185ffebb2de7b1fb5f6ad4d92e9d8ad3b2d3207721e8db14e7ac1f3d716d0b1a)(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)
@@ -10427,7 +10396,7 @@ snapshots:
       '@rushstack/heft-lint-plugin': 1.1.2(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)
       '@rushstack/heft-sass-plugin': 0.15.24(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)
       '@rushstack/heft-typescript-plugin': 1.1.2(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)
-      '@rushstack/heft-webpack5-plugin': 1.2.2(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)(tslib@2.3.1)(webpack@5.95.0)
+      '@rushstack/heft-webpack5-plugin': 1.2.2(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)(webpack@5.95.0)
       '@types/heft-jest': 1.0.2
       '@types/webpack-env': 1.15.3
       jest-environment-jsdom: 29.5.0
@@ -10450,7 +10419,6 @@ snapshots:
       - react-native-b4a
       - supports-color
       - ts-node
-      - tslib
       - uglify-js
       - utf-8-validate
       - webpack-cli
@@ -10984,7 +10952,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-webpack5-plugin@1.2.2(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)(tslib@2.3.1)(webpack@5.95.0)':
+  '@rushstack/heft-webpack5-plugin@1.2.2(@rushstack/heft@1.1.2(@types/node@22.19.13))(@types/node@22.19.13)(webpack@5.95.0)':
     dependencies:
       '@rushstack/debug-certificate-manager': 1.6.2(@types/node@22.19.13)
       '@rushstack/heft': 1.1.2(@types/node@22.19.13)
@@ -10993,13 +10961,12 @@ snapshots:
       tapable: 1.1.3
       watchpack: 2.4.0
       webpack: 5.95.0
-      webpack-dev-server: 5.2.3(tslib@2.3.1)(webpack@5.95.0)
+      webpack-dev-server: 5.2.3(webpack@5.95.0)
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
       - debug
       - supports-color
-      - tslib
       - utf-8-validate
       - webpack-cli
 
@@ -11018,7 +10985,6 @@ snapshots:
       - bufferutil
       - debug
       - supports-color
-      - tslib
       - utf-8-validate
       - webpack-cli
 
@@ -11388,10 +11354,6 @@ snapshots:
     dependencies:
       '@types/jest': 30.0.0
 
-  '@types/heft-jest@1.0.6':
-    dependencies:
-      '@types/jest': 30.0.0
-
   '@types/http-errors@2.0.5': {}
 
   '@types/http-proxy@1.17.17':
@@ -11410,8 +11372,8 @@ snapshots:
 
   '@types/jest@30.0.0':
     dependencies:
-      expect: 30.2.0
-      pretty-format: 30.2.0
+      expect: 30.3.0
+      pretty-format: 30.3.0
 
   '@types/jsdom@20.0.1':
     dependencies:
@@ -13282,15 +13244,6 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expect@30.2.0:
-    dependencies:
-      '@jest/expect-utils': 30.2.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.2.0
-      jest-message-util: 30.2.0
-      jest-mock: 30.2.0
-      jest-util: 30.2.0
-
   expect@30.3.0:
     dependencies:
       '@jest/expect-utils': 30.3.0
@@ -14122,13 +14075,6 @@ snapshots:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
 
-  jest-diff@30.2.0:
-    dependencies:
-      '@jest/diff-sequences': 30.0.1
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.2.0
-
   jest-diff@30.3.0:
     dependencies:
       '@jest/diff-sequences': 30.3.0
@@ -14269,13 +14215,6 @@ snapshots:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
-
-  jest-matcher-utils@30.2.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.2.0
-      pretty-format: 30.2.0
 
   jest-matcher-utils@30.3.0:
     dependencies:
@@ -14911,7 +14850,7 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.3.1)
       tslib: 2.3.1
 
-  memfs@4.56.11(tslib@2.3.1):
+  memfs@4.56.11:
     dependencies:
       '@jsonjoy.com/fs-core': 4.56.11(tslib@2.3.1)
       '@jsonjoy.com/fs-fsa': 4.56.11(tslib@2.3.1)
@@ -16445,70 +16384,27 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@7.4.5(tslib@2.3.1)(webpack@5.95.0):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 4.56.11(tslib@2.3.1)
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.95.0
-    transitivePeerDependencies:
-      - tslib
-
   webpack-dev-middleware@7.4.5(webpack@5.105.4):
     dependencies:
       colorette: 2.0.20
-      memfs: 4.56.11(tslib@2.3.1)
+      memfs: 4.56.11
       mime-types: 3.0.2
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
       webpack: 5.105.4
-    transitivePeerDependencies:
-      - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.3.1)(webpack@5.95.0):
+  webpack-dev-middleware@7.4.5(webpack@5.95.0):
     dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
-      ipaddr.js: 2.3.0
-      launch-editor: 2.13.1
-      open: 10.2.0
-      p-retry: 6.2.1
+      memfs: 4.56.11
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      range-parser: 1.2.1
       schema-utils: 4.3.3
-      selfsigned: 5.5.0
-      serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.3.1)(webpack@5.95.0)
-      ws: 8.19.0
     optionalDependencies:
       webpack: 5.95.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
 
   webpack-dev-server@5.2.3(webpack@5.105.4):
     dependencies:
@@ -16546,7 +16442,44 @@ snapshots:
       - bufferutil
       - debug
       - supports-color
-      - tslib
+      - utf-8-validate
+
+  webpack-dev-server@5.2.3(webpack@5.95.0):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.8
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.10
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.18.1
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.3.0
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.8.1
+      connect-history-api-fallback: 2.0.0
+      express: 4.22.1
+      graceful-fs: 4.2.11
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      ipaddr.js: 2.3.0
+      launch-editor: 2.13.1
+      open: 10.2.0
+      p-retry: 6.2.1
+      schema-utils: 4.3.3
+      selfsigned: 5.5.0
+      serve-index: 1.9.2
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.4.5(webpack@5.95.0)
+      ws: 8.19.0
+    optionalDependencies:
+      webpack: 5.95.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
       - utf-8-validate
 
   webpack-merge@5.8.0:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "e8475767f70d7b56e4ae80921b990c7f340cf6dc",
+  "pnpmShrinkwrapHash": "06ea930d9087f441fb42bdd4d268c4d86a17dbde",
   "preferredVersionsHash": "60ab45f0ccbf5e7f829439abd932739a522fddce"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f4433d3446e77e0c236917f32c21b30dbc165d72",
-  "preferredVersionsHash": "008ffd0c0339b2aa61ba2c6c7ec898a29be204d6"
+  "pnpmShrinkwrapHash": "e8475767f70d7b56e4ae80921b990c7f340cf6dc",
+  "preferredVersionsHash": "60ab45f0ccbf5e7f829439abd932739a522fddce"
 }

--- a/common/config/validation/rush-package-lock.json
+++ b/common/config/validation/rush-package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/rush": "5.172.1"
+        "@microsoft/rush": "5.175.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@azure/core-http-compat": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.2.tgz",
-      "integrity": "sha512-Tf6ltdKzOJEgxZeWLCjMxrxbodB/ZeCbzzA1A2qHbhzAjzjHoBVSUeSl/baT/oHAxhc4qdqVaDKnc2+iE932gw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2"
@@ -144,12 +144,12 @@
       }
     },
     "node_modules/@azure/core-xml": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
-      "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "^5.0.7",
+        "fast-xml-parser": "^5.5.9",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.5.0.tgz",
-      "integrity": "sha512-EknvVmtBuSIic47xkOqyNabAme0RYTw52BTMz8eBgU1ysTyMrD1uOoM+JdS0J/4Yfp98IBT3osqq3BfwSaNaGQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -169,16 +169,13 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.26.1",
-        "@azure/msal-node": "^2.15.0",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -195,62 +192,83 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.30.0.tgz",
-      "integrity": "sha512-I0XlIGVdM4E9kYP5eTjgW8fgATdzwxJvQ6bm2PNiHaZhEuUz47NYw1xHthC9R+lXz4i9zbShS0VdLyxd7n0GGA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.7.0.tgz",
+      "integrity": "sha512-uYbJ0YarxkVGWEq814BysJry/IPvpDNkVKmc2bMZp4G+igUQkJ5nlFirycwPGUeA9ICLQqCxqExCA1Z1E07bPA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.16.1"
+        "@azure/msal-common": "16.5.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.0.tgz",
+      "integrity": "sha512-i3eS/5pmxDbIU/mLMENs88Qg3k6XxqJytJy6PpB7L1tCBjdXHJDadCD3Hu1TyTooe7iQo7CYqbocgL/l/8u90g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.3.tgz",
-      "integrity": "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.3.tgz",
+      "integrity": "sha512-LqT8mRZpEils9zGR9eW+Ljqifh2aMA99UF/X0jxIKDYZeHr6onlHwhVP4xHCeLhh55BI63JCbdf1iWJbMh1mPw==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.16.1",
+        "@azure/msal-common": "16.5.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.26.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.26.0.tgz",
-      "integrity": "sha512-SriLPKezypIsiZ+TtlFfE46uuBIap2HeaQVS78e1P7rz5OSbq0rsd52WE1mC5f7vAeLiXqv7I7oRhL3WFZEw3Q==",
+      "version": "12.31.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
+      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-client": "^1.6.2",
-        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
         "@azure/core-lro": "^2.2.0",
-        "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.10.1",
-        "@azure/core-tracing": "^1.1.2",
-        "@azure/core-util": "^1.6.1",
-        "@azure/core-xml": "^1.4.3",
-        "@azure/logger": "^1.0.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.3.0",
         "events": "^3.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
+      "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -276,17 +294,167 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
+      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
       "license": "MIT",
       "dependencies": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
+      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
+      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
+      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.7.tgz",
+      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.3.tgz",
+      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -343,15 +511,15 @@
       }
     },
     "node_modules/@microsoft/rush": {
-      "version": "5.172.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/rush/-/rush-5.172.1.tgz",
-      "integrity": "sha512-ZHaUjORNrWuXoOkywb1qcZ5WSfJfWrLiJLWRhDdaODI9LXpI0cgMeT4UYqvG4YUDHgpbCAo5I2cWmh7VxL/rJg==",
+      "version": "5.175.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/rush/-/rush-5.175.0.tgz",
+      "integrity": "sha512-BG0SQqJ+7jmtRqSClaJdA/0dxdoQZzVzLl0lUszGn5jD8DylMIVhPQl6obYy/Qli1aa6CnXVzdG3NHAYhimZQQ==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/rush-lib": "5.172.1",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/terminal": "0.22.3",
-        "semver": "~7.5.4"
+        "@microsoft/rush-lib": "5.175.0",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/terminal": "0.23.0",
+        "semver": "~7.7.4"
       },
       "bin": {
         "rush": "bin/rush",
@@ -363,48 +531,48 @@
       }
     },
     "node_modules/@microsoft/rush-lib": {
-      "version": "5.172.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-5.172.1.tgz",
-      "integrity": "sha512-H06FppSFWfvEL4gb9ZfzamEWjJyF/3hdkMydTurVY7uup27fZMDhg4ZtkLunbLZpUxIf+kxZzrBLMwV1+IXUKg==",
+      "version": "5.175.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-5.175.0.tgz",
+      "integrity": "sha512-FyseuJGvFQvToPdgF92KXJimnn3BIgkPwOKZTiJVTOLX8tzm6IWzv8SJ3SVmiwEiOaDy+AeL8q3Hc6+NbI0skw==",
       "license": "MIT",
       "dependencies": {
+        "@inquirer/checkbox": "~5.1.3",
+        "@inquirer/confirm": "~6.0.11",
+        "@inquirer/input": "~5.0.11",
+        "@inquirer/search": "~4.1.7",
+        "@inquirer/select": "~5.1.3",
         "@pnpm/link-bins": "~5.3.7",
-        "@rushstack/credential-cache": "0.2.7",
-        "@rushstack/heft-config-file": "0.20.3",
-        "@rushstack/lookup-by-path": "0.9.7",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/npm-check-fork": "0.2.7",
-        "@rushstack/package-deps-hash": "4.7.7",
-        "@rushstack/package-extractor": "0.12.9",
-        "@rushstack/rig-package": "0.7.2",
-        "@rushstack/rush-amazon-s3-build-cache-plugin": "5.172.1",
-        "@rushstack/rush-azure-storage-build-cache-plugin": "5.172.1",
-        "@rushstack/rush-http-build-cache-plugin": "5.172.1",
-        "@rushstack/rush-pnpm-kit-v10": "0.2.8",
-        "@rushstack/rush-pnpm-kit-v8": "0.2.8",
-        "@rushstack/rush-pnpm-kit-v9": "0.2.8",
-        "@rushstack/stream-collator": "4.2.7",
-        "@rushstack/terminal": "0.22.3",
-        "@rushstack/ts-command-line": "5.3.3",
+        "@rushstack/credential-cache": "0.2.15",
+        "@rushstack/heft-config-file": "0.20.9",
+        "@rushstack/lookup-by-path": "0.10.4",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/npm-check-fork": "0.2.15",
+        "@rushstack/package-deps-hash": "4.7.15",
+        "@rushstack/package-extractor": "0.13.3",
+        "@rushstack/rig-package": "0.7.3",
+        "@rushstack/rush-amazon-s3-build-cache-plugin": "5.175.0",
+        "@rushstack/rush-azure-storage-build-cache-plugin": "5.175.0",
+        "@rushstack/rush-http-build-cache-plugin": "5.175.0",
+        "@rushstack/rush-pnpm-kit-v10": "0.2.16",
+        "@rushstack/rush-pnpm-kit-v8": "0.2.16",
+        "@rushstack/rush-pnpm-kit-v9": "0.2.16",
+        "@rushstack/stream-collator": "4.2.15",
+        "@rushstack/terminal": "0.23.0",
+        "@rushstack/ts-command-line": "5.3.8",
         "@yarnpkg/lockfile": "~1.0.2",
-        "builtin-modules": "~3.1.0",
-        "cli-table": "~0.3.1",
         "dependency-path": "~9.2.8",
         "dotenv": "~16.4.7",
         "fast-glob": "~3.3.1",
-        "figures": "3.0.0",
         "git-repo-info": "~2.1.0",
-        "glob-escape": "~0.0.2",
         "https-proxy-agent": "~5.0.0",
         "ignore": "~5.1.6",
-        "inquirer": "~8.2.7",
         "js-yaml": "~4.1.0",
         "npm-package-arg": "~6.1.0",
         "object-hash": "3.0.0",
         "pnpm-sync-lib": "0.3.3",
         "read-package-tree": "~5.1.5",
         "rxjs": "~6.6.7",
-        "semver": "~7.5.4",
+        "semver": "~7.7.4",
         "ssri": "~8.0.0",
         "strict-uri-encode": "~2.0.0",
         "tapable": "2.2.1",
@@ -414,6 +582,18 @@
       "engines": {
         "node": ">=5.6.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -574,18 +754,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@pnpm/dependency-path-pnpm-v10/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@pnpm/dependency-path-pnpm-v8": {
       "name": "@pnpm/dependency-path",
       "version": "2.1.8",
@@ -675,18 +843,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@pnpm/dependency-path-pnpm-v9/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@pnpm/dependency-path/node_modules/@pnpm/crypto.hash": {
       "version": "1000.2.2",
       "resolved": "https://registry.npmjs.org/@pnpm/crypto.hash/-/crypto.hash-1000.2.2.tgz",
@@ -744,18 +900,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@pnpm/dependency-path/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@pnpm/dependency-path/node_modules/ssri": {
@@ -992,30 +1136,6 @@
         "url": "https://opencollective.com/ramda"
       }
     },
-    "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/write-file-atomic": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -1069,18 +1189,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@pnpm/lockfile.merger/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@pnpm/lockfile.types": {
@@ -1455,24 +1563,23 @@
       }
     },
     "node_modules/@rushstack/credential-cache": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/credential-cache/-/credential-cache-0.2.7.tgz",
-      "integrity": "sha512-5vYUGreyf0ZvQ5lLFsQHLbJe1//hBZeI8G7BMoyDaLt4/uegfHNTmiXgYNXDQaqpnM9ImHyXSuOS/DrcbM3aMA==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rushstack/credential-cache/-/credential-cache-0.2.15.tgz",
+      "integrity": "sha512-Wl6xTWYRA0vWi4zzbBfXV6kmwNpdHMaYpr6hueDtEfoo5NujfPoL2RFeGmQr5Vy4cB5xY7LJDh/A4fJRx1qKFA==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.3"
+        "@rushstack/node-core-library": "5.23.1"
       }
     },
     "node_modules/@rushstack/heft-config-file": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/heft-config-file/-/heft-config-file-0.20.3.tgz",
-      "integrity": "sha512-kVIBNxwtgV4wPQrqk4PCcaU3DKkmDmiULkELmb7RmhYKAYqR6XyA9dnyXdu/HgmF3zPn8EnuBT8/RhlKmbF8Zg==",
+      "version": "0.20.9",
+      "resolved": "https://registry.npmjs.org/@rushstack/heft-config-file/-/heft-config-file-0.20.9.tgz",
+      "integrity": "sha512-atd6I956PaMkmplG6zwJaETMD1I1TWoAa8/yC/JTxmVdiineInSFedRl75uQXfOGFE1YLIbGLrZISi3QzMXhpA==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/rig-package": "0.7.2",
-        "@rushstack/terminal": "0.22.3",
-        "@ungap/structured-clone": "~1.3.0",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rig-package": "0.7.3",
+        "@rushstack/terminal": "0.23.0",
         "jsonpath-plus": "~10.3.0"
       },
       "engines": {
@@ -1480,9 +1587,9 @@
       }
     },
     "node_modules/@rushstack/lookup-by-path": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/lookup-by-path/-/lookup-by-path-0.9.7.tgz",
-      "integrity": "sha512-wlyXv5n0scQF7DEcv4KcFxsoVbSLXfZhVvS91S6gc6fOWpLoqIzSGANY9yIQtQpyJqrr0vwLUppa+zv/CB4sYw==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@rushstack/lookup-by-path/-/lookup-by-path-0.10.4.tgz",
+      "integrity": "sha512-tOUFYpiaOWGkYM+pSOYjlmgHjHVmuldjq9duRa3IQv0Ho0/vZZUg2v8D65ydnQ1WK4MkqnkLeZU85jkV6275Tw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/node": "*"
@@ -1494,9 +1601,9 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
-      "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "~8.18.0",
@@ -1506,7 +1613,7 @@
         "import-lazy": "~4.0.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.1",
-        "semver": "~7.5.4"
+        "semver": "~7.7.4"
       },
       "peerDependencies": {
         "@types/node": "*"
@@ -1518,41 +1625,39 @@
       }
     },
     "node_modules/@rushstack/npm-check-fork": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/npm-check-fork/-/npm-check-fork-0.2.7.tgz",
-      "integrity": "sha512-ZCNkfge+qpXK/SBR+MA6hcYRP0KGd1npSXy0zsLl8Rb7JGY+uE/GhOUNVnw9FXtam7oK8j7WSOQFd64u9kO4dg==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rushstack/npm-check-fork/-/npm-check-fork-0.2.15.tgz",
+      "integrity": "sha512-EEV6mbpOCqsv7llSe07porwAHMADSQQhLICK0M9xX5QWnX65dUNEsvXFUBxDEn1VCmMZ6q2Fa3S76ilWhQIVyA==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.3",
-        "giturl": "^2.0.0",
-        "lodash": "~4.17.23",
-        "semver": "~7.5.4"
+        "@rushstack/node-core-library": "5.23.1",
+        "semver": "~7.7.4"
       }
     },
     "node_modules/@rushstack/package-deps-hash": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/package-deps-hash/-/package-deps-hash-4.7.7.tgz",
-      "integrity": "sha512-nj7wspFmch+SmPr6RT46zO9aKGD6IjVBP8z3JMmiiJq5p7WgNyqEENOBWGZ42Hwpav9qjj9hWxMggHJiwLg3mA==",
+      "version": "4.7.15",
+      "resolved": "https://registry.npmjs.org/@rushstack/package-deps-hash/-/package-deps-hash-4.7.15.tgz",
+      "integrity": "sha512-2P+/X5K8l+Hjqa2nyjNOD8DY3uvu3Y7SP8iTfRudnV13voi4Wmwbw6Jh8Inif+v+pLj/tcZS9M3uweU2jDuRUg==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.3"
+        "@rushstack/node-core-library": "5.23.1"
       }
     },
     "node_modules/@rushstack/package-extractor": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/@rushstack/package-extractor/-/package-extractor-0.12.9.tgz",
-      "integrity": "sha512-gT0F+Au0IunVyax16KiFfudoZ+m6luPLy1JD1Pmhukx1TxAHkB8P4tweLJAjP+rxdel5PAd93ewCUpaaFXwcRQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/package-extractor/-/package-extractor-0.13.3.tgz",
+      "integrity": "sha512-BpKbk/lQHAEWAC5eQxyZ/6FWDYOgKmu05+Y2WWp4i5ibKUPctqoueR9Z7hejsJY87JuaK/gkuTZsJzBSaq+u/g==",
       "license": "MIT",
       "dependencies": {
         "@pnpm/link-bins": "~5.3.7",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/terminal": "0.22.3",
-        "@rushstack/ts-command-line": "5.3.3",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/terminal": "0.23.0",
+        "@rushstack/ts-command-line": "5.3.8",
         "ignore": "~5.1.6",
         "jszip": "~3.8.0",
         "minimatch": "10.2.3",
         "npm-packlist": "~5.1.3",
-        "semver": "~7.5.4"
+        "semver": "~7.7.4"
       }
     },
     "node_modules/@rushstack/problem-matcher": {
@@ -1570,58 +1675,58 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.2.tgz",
-      "integrity": "sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+      "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
       "license": "MIT",
       "dependencies": {
-        "resolve": "~1.22.1",
-        "strip-json-comments": "~3.1.1"
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1"
       }
     },
     "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin": {
-      "version": "5.172.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-amazon-s3-build-cache-plugin/-/rush-amazon-s3-build-cache-plugin-5.172.1.tgz",
-      "integrity": "sha512-kOxggLrYy5x0idTkDBsCFknMJYxuHx5bue19xkOLJ8BvM9PIqJ5sYZZrxmryquidcAOAITCowHMeiA2OglhdiQ==",
+      "version": "5.175.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-amazon-s3-build-cache-plugin/-/rush-amazon-s3-build-cache-plugin-5.175.0.tgz",
+      "integrity": "sha512-p4Ycbh7foAmv7+iPBTzRF2qOR5wzrOc1mb9wNjaSGXo1Y6FcO7U2eWLSA4UihHVUuLFj7UFt2zxTSCs0NhqbKA==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/credential-cache": "0.2.7",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/rush-sdk": "5.172.1",
-        "@rushstack/terminal": "0.22.3",
+        "@rushstack/credential-cache": "0.2.15",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rush-sdk": "5.175.0",
+        "@rushstack/terminal": "0.23.0",
         "https-proxy-agent": "~5.0.0"
       }
     },
     "node_modules/@rushstack/rush-azure-storage-build-cache-plugin": {
-      "version": "5.172.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-azure-storage-build-cache-plugin/-/rush-azure-storage-build-cache-plugin-5.172.1.tgz",
-      "integrity": "sha512-VXs63Yj5+SIKjIbafiVQOSqBK7HKZIAqbrAcKkP0BTwRW9wgjO3PxkVeBc++OPKh8H/CH6iJFqzNK+BCjO6oQw==",
+      "version": "5.175.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-azure-storage-build-cache-plugin/-/rush-azure-storage-build-cache-plugin-5.175.0.tgz",
+      "integrity": "sha512-O+QqAeH5z+AgmhUTYQE6wqyfqtYhZloiA0WMPJb3KLIaiRwayV0n4itMTu2UrdkXx8Hq/j08FXXxPum4Vc1ReA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "~4.5.0",
-        "@azure/storage-blob": "~12.26.0",
-        "@rushstack/credential-cache": "0.2.7",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/rush-sdk": "5.172.1",
-        "@rushstack/terminal": "0.22.3"
+        "@azure/identity": "~4.13.1",
+        "@azure/storage-blob": "~12.31.0",
+        "@rushstack/credential-cache": "0.2.15",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rush-sdk": "5.175.0",
+        "@rushstack/terminal": "0.23.0"
       }
     },
     "node_modules/@rushstack/rush-http-build-cache-plugin": {
-      "version": "5.172.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-http-build-cache-plugin/-/rush-http-build-cache-plugin-5.172.1.tgz",
-      "integrity": "sha512-NfGFGDJzrWM1pHoLFytZ86diuvAdQ1RddJsStLaGmgzgTJBuAWHvwRrBoh55LRA9IBOoMGAEiv3RVtipjoclAQ==",
+      "version": "5.175.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-http-build-cache-plugin/-/rush-http-build-cache-plugin-5.175.0.tgz",
+      "integrity": "sha512-KbFg2xS2WankLoYTJn6OQB/z1eW1jKYfw3jy12bIhvgIhyO1IshxlmU6IrX46NKBDfoAlMHTzDdGC+aGVLgSSw==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/credential-cache": "0.2.7",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/rush-sdk": "5.172.1",
+        "@rushstack/credential-cache": "0.2.15",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rush-sdk": "5.175.0",
         "https-proxy-agent": "~5.0.0"
       }
     },
     "node_modules/@rushstack/rush-pnpm-kit-v10": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-pnpm-kit-v10/-/rush-pnpm-kit-v10-0.2.8.tgz",
-      "integrity": "sha512-u4mRegXxtLz4T5Bx5aYumTWGcaeSwUE9xpnh/PusC14lxzcAhdCHEsicd+6VRcJOPnRqfZjNVPaBQx6N94WyPA==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-pnpm-kit-v10/-/rush-pnpm-kit-v10-0.2.16.tgz",
+      "integrity": "sha512-EpcquewnOw4nhnytlFDkI5onHPzo7ePeQuyTJtVIHMWqVlx43tO18uP1GFR8CytGqBQYIUPiLiLaLPl7Rnsiog==",
       "license": "MIT",
       "dependencies": {
         "@pnpm/dependency-path-pnpm-v10": "npm:@pnpm/dependency-path@~1000.0.9",
@@ -1630,9 +1735,9 @@
       }
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-pnpm-kit-v8/-/rush-pnpm-kit-v8-0.2.8.tgz",
-      "integrity": "sha512-Jw/qBr4ONJ5Jj+nnEZ0jxyCnxZQeFjyePovdEPQXZ8E4Q/hrT8GbEYeNVTi8VWrVe5odb5f5MfPp0zP5J2EHOg==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-pnpm-kit-v8/-/rush-pnpm-kit-v8-0.2.16.tgz",
+      "integrity": "sha512-h75p27+cGm61gGRFqW4skNf98t1d5n7/OhVwZ/g+waNdiPQwwfAoLc+CKG6W+lAQ9S25GLLMM1CmJBhA63pgIw==",
       "license": "MIT",
       "dependencies": {
         "@pnpm/dependency-path-pnpm-v8": "npm:@pnpm/dependency-path@~2.1.8",
@@ -1811,18 +1916,6 @@
         "url": "https://opencollective.com/ramda"
       }
     },
-    "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/write-file-atomic": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -1837,9 +1930,9 @@
       }
     },
     "node_modules/@rushstack/rush-pnpm-kit-v9": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-pnpm-kit-v9/-/rush-pnpm-kit-v9-0.2.8.tgz",
-      "integrity": "sha512-4ZYSS3HkkT/mqJCgCSoDnKE2wqBFORysk30hSsmj6C3cL+iK0laQgY5zn1hY0DJvkeskiSWuMu1Pjmahs0mgSw==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-pnpm-kit-v9/-/rush-pnpm-kit-v9-0.2.16.tgz",
+      "integrity": "sha512-6h9qFq/aziKihnpuYvc4wKvup5+H5OTajBeOh4sUby/eb0tNTeJkH1M1yxQHtN5t5u/OSwRdgPxHzjwHNlDfpQ==",
       "license": "MIT",
       "dependencies": {
         "@pnpm/dependency-path-pnpm-v9": "npm:@pnpm/dependency-path@~5.1.7",
@@ -1848,37 +1941,37 @@
       }
     },
     "node_modules/@rushstack/rush-sdk": {
-      "version": "5.172.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/rush-sdk/-/rush-sdk-5.172.1.tgz",
-      "integrity": "sha512-/szoWiIML50LD4Zmsbzflkw4pC7P8DwPvMqszaOeMT6ahxEBnf2F3Ptfn6rlEFvSVpiV7ESab2wGuAc+wlSTBg==",
+      "version": "5.175.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-sdk/-/rush-sdk-5.175.0.tgz",
+      "integrity": "sha512-Fs7Q2Rb378QH8zIeAD5r0Uud5+6Ntop85PUm+sJwe6vQant6pytsdJz4QIRKyecRzdQ9R2CAcfLilC14CClykQ==",
       "license": "MIT",
       "dependencies": {
         "@pnpm/lockfile.types-900": "npm:@pnpm/lockfile.types@~900.0.0",
-        "@rushstack/credential-cache": "0.2.7",
-        "@rushstack/lookup-by-path": "0.9.7",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/package-deps-hash": "4.7.7",
-        "@rushstack/terminal": "0.22.3",
+        "@rushstack/credential-cache": "0.2.15",
+        "@rushstack/lookup-by-path": "0.10.4",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/package-deps-hash": "4.7.15",
+        "@rushstack/terminal": "0.23.0",
         "tapable": "2.2.1"
       }
     },
     "node_modules/@rushstack/stream-collator": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/stream-collator/-/stream-collator-4.2.7.tgz",
-      "integrity": "sha512-USuC0VdqYdKJ1xs8Czse5on4y2tx53zgqnDHG2UzOmhOIsHmmyWhPbq6PzurOZ3Ll9DnB2ty1ZGo1tI1brgzeQ==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@rushstack/stream-collator/-/stream-collator-4.2.15.tgz",
+      "integrity": "sha512-F+70DZlQSNh/qXXVtIcpd7MC0otlqLrB0QwYn0nSBaN0AsBtJUoPIEifmvouOdm8HTRbyKkA91KDA2ArtV3gOg==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/terminal": "0.22.3"
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/terminal": "0.23.0"
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.3.tgz",
-      "integrity": "sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.23.0.tgz",
+      "integrity": "sha512-7FfI9irLqnBDxCvMEXdEXLDjaouZsGbKkeGfmW8IOn8aYi7DV9aaXaEQHCcVxWMvEDOkuTf4y6RMDgIY5CFuUQ==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.3",
+        "@rushstack/node-core-library": "5.23.1",
         "@rushstack/problem-matcher": "0.2.1",
         "supports-color": "~8.1.1"
       },
@@ -1892,12 +1985,12 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.3.tgz",
-      "integrity": "sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.8.tgz",
+      "integrity": "sha512-vKL4fVR2TdnMdCmlP71nZUzbNANOYlR7NfN+J/YL9UIvicDIEB+ZtH38LcJECOZUwHia8C5Mg98kc4kPt/ev5w==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.22.3",
+        "@rushstack/terminal": "0.23.0",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -1910,9 +2003,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
-      "integrity": "sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -1935,12 +2028,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "license": "ISC"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.0.2",
@@ -2048,45 +2135,6 @@
         }
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2117,26 +2165,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -2147,31 +2175,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bole": {
@@ -2208,44 +2211,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/builtins": {
       "version": "1.0.3",
@@ -2253,39 +2223,20 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "license": "MIT"
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "run-applescript": "^7.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
-      "license": "MIT"
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -2296,57 +2247,13 @@
         "node": ">=18"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-table": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
-      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
-      "dependencies": {
-        "colors": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
     "node_modules/cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
+        "node": ">= 12"
       }
     },
     "node_modules/cmd-extension": {
@@ -2356,33 +2263,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/comver-to-semver": {
@@ -2447,25 +2327,44 @@
         "node": "*"
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
       "dependencies": {
-        "clone": "^1.0.2"
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dependency-path": {
@@ -2553,12 +2452,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
     "node_modules/encode-registry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/encode-registry/-/encode-registry-3.0.1.tgz",
@@ -2580,13 +2473,13 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">= 0.4"
       }
     },
     "node_modules/events": {
@@ -2636,6 +2529,12 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2664,6 +2563,21 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2680,10 +2594,19 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -2696,9 +2619,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -2707,9 +2630,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2722,18 +2646,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-      "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fill-range": {
@@ -2807,15 +2719,6 @@
         "node": ">= 4.0"
       }
     },
-    "node_modules/giturl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giturl/-/giturl-2.0.0.tgz",
-      "integrity": "sha512-FB0MmghWLcqsyrBZyqsLCNeS2kIzYymT34t/6BxM5R0/9Pxvj0K1eK25SBbwRHMjKMLgQ7nYqBSduF6XyfkgFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
     "node_modules/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -2834,15 +2737,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-escape": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/glob-escape/-/glob-escape-0.0.2.tgz",
-      "integrity": "sha512-L/cXYz8x7qer1HAyUQ+mbjcUsJVdpRxpAf7CwqHoNBs9vTpABlGfNN4tzkDxt+u3Z7ZncVyKlCNPtzb0R/7WbA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/glob-parent": {
@@ -2864,9 +2758,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2900,9 +2794,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2970,42 +2864,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
@@ -3034,9 +2892,9 @@
       "license": "MIT"
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3100,41 +2958,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/inquirer": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
-      "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/external-editor": "^1.0.0",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3157,15 +2980,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3180,15 +3003,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3201,13 +3015,22 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
+    "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -3258,18 +3081,6 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
     },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3280,15 +3091,18 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -3487,21 +3301,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -3543,22 +3342,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3701,10 +3484,13 @@
       "license": "MIT"
     },
     "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "license": "ISC"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -3913,40 +3699,18 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "license": "MIT",
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4064,9 +3828,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -4192,9 +3956,9 @@
       "license": "MIT"
     },
     "node_modules/read-package-json/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4338,11 +4102,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -4355,19 +4120,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/reusify": {
@@ -4409,9 +4161,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4451,13 +4203,16 @@
         "node": "*"
       }
     },
-    "node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.12.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -4521,20 +4276,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4573,10 +4319,16 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sort-keys": {
       "version": "4.2.0",
@@ -4652,16 +4404,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
-      }
-    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -4695,32 +4437,6 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -4739,22 +4455,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -4854,12 +4558,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
-    },
     "node_modules/through2": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
@@ -4908,15 +4606,12 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -4971,15 +4666,6 @@
         "builtins": "^1.0.3"
       }
     },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4993,20 +4679,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -5027,6 +4699,12 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/write-yaml-file": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/write-yaml-file/-/write-yaml-file-4.2.0.tgz",
@@ -5038,6 +4716,21 @@
       },
       "engines": {
         "node": ">=10.13"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yallist": {

--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -48,12 +48,6 @@ module.exports = require("node:path");
 /******/ 		if (cachedModule !== undefined) {
 /******/ 			return cachedModule.exports;
 /******/ 		}
-/******/ 		// Check if module exists (development only)
-/******/ 		if (__webpack_modules__[moduleId] === undefined) {
-/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
-/******/ 			e.code = 'MODULE_NOT_FOUND';
-/******/ 			throw e;
-/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {
 /******/ 			// no module.id needed
@@ -62,6 +56,12 @@ module.exports = require("node:path");
 /******/ 		};
 /******/
 /******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
 /******/
 /******/ 		// Return the exports of the module

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -361,12 +361,6 @@ module.exports = require("node:path");
 /******/ 		if (cachedModule !== undefined) {
 /******/ 			return cachedModule.exports;
 /******/ 		}
-/******/ 		// Check if module exists (development only)
-/******/ 		if (__webpack_modules__[moduleId] === undefined) {
-/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
-/******/ 			e.code = 'MODULE_NOT_FOUND';
-/******/ 			throw e;
-/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {
 /******/ 			// no module.id needed
@@ -375,6 +369,12 @@ module.exports = require("node:path");
 /******/ 		};
 /******/
 /******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
 /******/
 /******/ 		// Return the exports of the module

--- a/examples/ace-data-visualization/package.json
+++ b/examples/ace-data-visualization/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/ace-data-visualization/package.json
+++ b/examples/ace-data-visualization/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/ace-generic-card/package.json
+++ b/examples/ace-generic-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/ace-generic-card/package.json
+++ b/examples/ace-generic-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/ace-generic-image-card/package.json
+++ b/examples/ace-generic-image-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/ace-generic-image-card/package.json
+++ b/examples/ace-generic-image-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/ace-generic-primarytext-card/package.json
+++ b/examples/ace-generic-primarytext-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/ace-generic-primarytext-card/package.json
+++ b/examples/ace-generic-primarytext-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/ace-search-card/package.json
+++ b/examples/ace-search-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/ace-search-card/package.json
+++ b/examples/ace-search-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/extension-application-customizer/package.json
+++ b/examples/extension-application-customizer/package.json
@@ -27,7 +27,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/extension-application-customizer/package.json
+++ b/examples/extension-application-customizer/package.json
@@ -28,7 +28,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/extension-fieldcustomizer-minimal/package.json
+++ b/examples/extension-fieldcustomizer-minimal/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/extension-fieldcustomizer-minimal/package.json
+++ b/examples/extension-fieldcustomizer-minimal/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/extension-fieldcustomizer-noframework/package.json
+++ b/examples/extension-fieldcustomizer-noframework/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/extension-fieldcustomizer-noframework/package.json
+++ b/examples/extension-fieldcustomizer-noframework/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/extension-fieldcustomizer-react/package.json
+++ b/examples/extension-fieldcustomizer-react/package.json
@@ -30,7 +30,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",

--- a/examples/extension-fieldcustomizer-react/package.json
+++ b/examples/extension-fieldcustomizer-react/package.json
@@ -29,7 +29,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",

--- a/examples/extension-formcustomizer-noframework/package.json
+++ b/examples/extension-formcustomizer-noframework/package.json
@@ -28,7 +28,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/extension-formcustomizer-noframework/package.json
+++ b/examples/extension-formcustomizer-noframework/package.json
@@ -29,7 +29,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/extension-formcustomizer-react/package.json
+++ b/examples/extension-formcustomizer-react/package.json
@@ -32,7 +32,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",

--- a/examples/extension-formcustomizer-react/package.json
+++ b/examples/extension-formcustomizer-react/package.json
@@ -31,7 +31,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",

--- a/examples/extension-listviewcommandset/package.json
+++ b/examples/extension-listviewcommandset/package.json
@@ -27,7 +27,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/extension-listviewcommandset/package.json
+++ b/examples/extension-listviewcommandset/package.json
@@ -28,7 +28,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/extension-search-query-modifier/package.json
+++ b/examples/extension-search-query-modifier/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/extension-search-query-modifier/package.json
+++ b/examples/extension-search-query-modifier/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/library/package.json
+++ b/examples/library/package.json
@@ -23,7 +23,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/library/package.json
+++ b/examples/library/package.json
@@ -24,7 +24,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/webpart-minimal/package.json
+++ b/examples/webpart-minimal/package.json
@@ -29,7 +29,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/webpart-minimal/package.json
+++ b/examples/webpart-minimal/package.json
@@ -30,7 +30,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/webpart-noframework/package.json
+++ b/examples/webpart-noframework/package.json
@@ -29,7 +29,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/examples/webpart-noframework/package.json
+++ b/examples/webpart-noframework/package.json
@@ -30,7 +30,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/examples/webpart-react/package.json
+++ b/examples/webpart-react/package.json
@@ -33,7 +33,7 @@
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.15",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",

--- a/examples/webpart-react/package.json
+++ b/examples/webpart-react/package.json
@@ -32,7 +32,7 @@
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/heft-jest": "^1.0.6",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.172.1",
+  "rushVersion": "5.175.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/templates/ace-data-visualization/package.json
+++ b/templates/ace-data-visualization/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/ace-data-visualization/package.json
+++ b/templates/ace-data-visualization/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/ace-generic-card/package.json
+++ b/templates/ace-generic-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/ace-generic-card/package.json
+++ b/templates/ace-generic-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/ace-generic-image-card/package.json
+++ b/templates/ace-generic-image-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/ace-generic-image-card/package.json
+++ b/templates/ace-generic-image-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/ace-generic-primarytext-card/package.json
+++ b/templates/ace-generic-primarytext-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/ace-generic-primarytext-card/package.json
+++ b/templates/ace-generic-primarytext-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/ace-search-card/package.json
+++ b/templates/ace-search-card/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/ace-search-card/package.json
+++ b/templates/ace-search-card/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/extension-application-customizer/package.json
+++ b/templates/extension-application-customizer/package.json
@@ -27,7 +27,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/extension-application-customizer/package.json
+++ b/templates/extension-application-customizer/package.json
@@ -28,7 +28,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/extension-fieldcustomizer-minimal/package.json
+++ b/templates/extension-fieldcustomizer-minimal/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/extension-fieldcustomizer-minimal/package.json
+++ b/templates/extension-fieldcustomizer-minimal/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/extension-fieldcustomizer-noframework/package.json
+++ b/templates/extension-fieldcustomizer-noframework/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/extension-fieldcustomizer-noframework/package.json
+++ b/templates/extension-fieldcustomizer-noframework/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/extension-fieldcustomizer-react/package.json
+++ b/templates/extension-fieldcustomizer-react/package.json
@@ -30,7 +30,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",

--- a/templates/extension-fieldcustomizer-react/package.json
+++ b/templates/extension-fieldcustomizer-react/package.json
@@ -29,7 +29,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",

--- a/templates/extension-formcustomizer-noframework/package.json
+++ b/templates/extension-formcustomizer-noframework/package.json
@@ -28,7 +28,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/extension-formcustomizer-noframework/package.json
+++ b/templates/extension-formcustomizer-noframework/package.json
@@ -29,7 +29,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/extension-formcustomizer-react/package.json
+++ b/templates/extension-formcustomizer-react/package.json
@@ -31,7 +31,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",

--- a/templates/extension-formcustomizer-react/package.json
+++ b/templates/extension-formcustomizer-react/package.json
@@ -32,7 +32,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",

--- a/templates/extension-listviewcommandset/package.json
+++ b/templates/extension-listviewcommandset/package.json
@@ -27,7 +27,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/extension-listviewcommandset/package.json
+++ b/templates/extension-listviewcommandset/package.json
@@ -28,7 +28,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/extension-search-query-modifier/package.json
+++ b/templates/extension-search-query-modifier/package.json
@@ -27,7 +27,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/extension-search-query-modifier/package.json
+++ b/templates/extension-search-query-modifier/package.json
@@ -26,7 +26,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/library/package.json
+++ b/templates/library/package.json
@@ -24,7 +24,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/library/package.json
+++ b/templates/library/package.json
@@ -23,7 +23,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/webpart-minimal/package.json
+++ b/templates/webpart-minimal/package.json
@@ -30,7 +30,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/webpart-minimal/package.json
+++ b/templates/webpart-minimal/package.json
@@ -29,7 +29,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/webpart-noframework/package.json
+++ b/templates/webpart-noframework/package.json
@@ -30,7 +30,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/templates/webpart-noframework/package.json
+++ b/templates/webpart-noframework/package.json
@@ -29,7 +29,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/templates/webpart-react/package.json
+++ b/templates/webpart-react/package.json
@@ -33,7 +33,7 @@
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
     "@types/webpack-env": "~1.15.2",

--- a/templates/webpart-react/package.json
+++ b/templates/webpart-react/package.json
@@ -32,7 +32,7 @@
     "@microsoft/sp-module-interfaces": "<%= spfxVersion %>",
     "@microsoft/spfx-web-build-rig": "<%= spfxVersion %>",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",

--- a/tests/spfx-template-test/package.json
+++ b/tests/spfx-template-test/package.json
@@ -16,14 +16,14 @@
   "dependencies": {
     "@microsoft/spfx-cli": "workspace:*",
     "@microsoft/spfx-template-api": "workspace:*",
-    "@rushstack/node-core-library": "~5.21.0",
-    "@rushstack/ts-command-line": "~5.3.4",
-    "@rushstack/terminal": "~0.22.4",
+    "@rushstack/node-core-library": "~5.23.1",
+    "@rushstack/ts-command-line": "~5.3.8",
+    "@rushstack/terminal": "~0.23.0",
     "ignore": "^5.3.0"
   },
   "devDependencies": {
     "@microsoft/spfx-cli-build-rig": "workspace:*",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "eslint": "9.37.0"
   }
 }

--- a/tests/spfx-template-test/src/tests/__snapshots__/multi-component.test.ts.snap
+++ b/tests/spfx-template-test/src/tests/__snapshots__/multi-component.test.ts.snap
@@ -139,7 +139,7 @@ Object {
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft": "^1.2.9",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",
     "eslint": "8.57.1",

--- a/tests/spfx-template-test/src/tests/__snapshots__/multi-component.test.ts.snap
+++ b/tests/spfx-template-test/src/tests/__snapshots__/multi-component.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Multi-component scaffolding should scaffold webpart-minimal then extension-application-customizer into same directory: merged config/config.json 1`] = `
 Object {
@@ -138,7 +138,7 @@ Object {
     "@microsoft/sp-module-interfaces": "1.22.2",
     "@microsoft/spfx-web-build-rig": "1.22.2",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "@types/jest": "30.0.0",
     "@types/webpack-env": "~1.15.2",
     "@typescript-eslint/parser": "8.48.1",

--- a/tests/spfx-template-test/src/tests/__snapshots__/templates.test.ts.snap
+++ b/tests/spfx-template-test/src/tests/__snapshots__/templates.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SPFx Template Scaffolding Template scaffolding and comparison should scaffold ace-data-visualization template and match example output: stdout 1`] = `
 "Adding local template source: <LOCAL_TEMPLATE_PATH>

--- a/tools/repo-toolbox/package.json
+++ b/tools/repo-toolbox/package.json
@@ -13,16 +13,16 @@
     "@octokit/request-error": "^7.1.0",
     "@octokit/rest": "^22.0.0",
     "@octokit/types": "^16.0.0",
-    "@rushstack/node-core-library": "~5.21.0",
-    "@rushstack/terminal": "~0.22.4",
-    "@rushstack/ts-command-line": "~5.3.4",
+    "@rushstack/node-core-library": "~5.23.1",
+    "@rushstack/terminal": "~0.23.0",
+    "@rushstack/ts-command-line": "~5.3.8",
     "azure-devops-node-api": "^14.1.0"
   },
   "devDependencies": {
     "@microsoft/spfx-cli-build-rig": "workspace:*",
-    "@rushstack/heft-webpack5-plugin": "^1.3.10",
-    "@rushstack/heft": "^1.2.9",
-    "@rushstack/webpack-preserve-dynamic-require-plugin": "^0.12.10",
+    "@rushstack/heft-webpack5-plugin": "^1.3.16",
+    "@rushstack/heft": "^1.2.15",
+    "@rushstack/webpack-preserve-dynamic-require-plugin": "^0.12.16",
     "eslint": "9.37.0",
     "webpack": "^5.99.0"
   }

--- a/tools/repo-toolbox/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/tools/repo-toolbox/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CommandLineHelp prints the help: create-github-releases 1`] = `
 "usage: repo-toolbox create-github-releases [-h] --github-token TOKEN

--- a/tools/repo-toolbox/src/utilities/test/__snapshots__/GitUtilities.test.ts.snap
+++ b/tools/repo-toolbox/src/utilities/test/__snapshots__/GitUtilities.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`GitUtilities getGitHubAuthorizationHeaderAsync normalizes basic-auth extraheader with a GitHub App token 1`] = `
 Array [

--- a/tools/spfx-cli-build-rig/package.json
+++ b/tools/spfx-cli-build-rig/package.json
@@ -25,7 +25,7 @@
     "@microsoft/api-extractor": "^7.58.5",
     "@rushstack/eslint-config": "4.6.4",
     "@rushstack/heft-node-rig": "^2.11.37",
-    "@types/heft-jest": "^1.0.6",
+    "@types/jest": "30.0.0",
     "@types/node": "^22.18.6",
     "eslint-import-resolver-node": "0.3.9",
     "eslint-plugin-headers": "~1.2.1",

--- a/tools/spfx-cli-build-rig/package.json
+++ b/tools/spfx-cli-build-rig/package.json
@@ -22,9 +22,9 @@
     "eslint": "9.37.0"
   },
   "dependencies": {
-    "@microsoft/api-extractor": "^7.58.0",
+    "@microsoft/api-extractor": "^7.58.5",
     "@rushstack/eslint-config": "4.6.4",
-    "@rushstack/heft-node-rig": "^2.11.29",
+    "@rushstack/heft-node-rig": "^2.11.37",
     "@types/heft-jest": "^1.0.6",
     "@types/node": "^22.18.6",
     "eslint-import-resolver-node": "0.3.9",
@@ -36,7 +36,7 @@
     "typescript": "~5.8.3"
   },
   "devDependencies": {
-    "@rushstack/heft": "^1.2.9",
+    "@rushstack/heft": "^1.2.15",
     "eslint": "9.37.0"
   }
 }

--- a/tools/spfx-cli-build-rig/profiles/default/tsconfig-base.json
+++ b/tools/spfx-cli-build-rig/profiles/default/tsconfig-base.json
@@ -33,7 +33,7 @@
     "skipLibCheck": true,
 
     // Type Definitions - Add Node types
-    "types": ["heft-jest", "node"],
+    "types": ["jest", "node"],
     "typeRoots": ["../../../../../node_modules/@types", "../../node_modules/@types"]
   },
   "include": ["../../../../../src/**/*.ts", "../../../../../src/**/*.tsx"]


### PR DESCRIPTION
## Description
Updates Rushstack dependencies across the repo:
- Rush: 5.172.1 → 5.175.0
- `@rushstack/node-core-library`: ~5.21.0 → ~5.23.1
- `@rushstack/ts-command-line`: ~5.3.4 → ~5.3.8
- `@rushstack/terminal`: ~0.22.4 → ~0.23.0
- `@rushstack/heft`: ^1.2.9 → ^1.2.15

Also updates lock files, `install-run.js` / `install-run-rush.js`, and `rush-package-lock.json` accordingly.

## How was this tested?
- `rush update` completed successfully
- `rush build` completed successfully

## Type of change
- [x] Documentation / CI / governance