### PR TITLE
Remove deprecated teams styling for Web Part no framework and react t…

### DIFF
--- a/examples/webpart-noframework/src/webparts/noFrameworkWebPart/NoFrameworkWebPart.module.scss
+++ b/examples/webpart-noframework/src/webparts/noFrameworkWebPart/NoFrameworkWebPart.module.scss
@@ -1,13 +1,8 @@
-@import '~@microsoft/sp-office-ui-fabric-core/dist/sass/SPFabricCore.scss';
-
 .noFrameworkWebPart {
   overflow: hidden;
   padding: 1em;
   color: "[theme:bodyText, default: #323130]";
   color: var(--bodyText);
-  &.teams {
-    font-family: $ms-font-family-fallbacks;
-  }
 }
 
 .welcome {

--- a/examples/webpart-noframework/src/webparts/noFrameworkWebPart/NoFrameworkWebPart.ts
+++ b/examples/webpart-noframework/src/webparts/noFrameworkWebPart/NoFrameworkWebPart.ts
@@ -23,7 +23,7 @@ export default class NoFrameworkWebPart extends BaseClientSideWebPart<INoFramewo
 
   public render(): void {
     this.domElement.innerHTML = `
-    <section class="${styles.noFrameworkWebPart} ${!!this.context.sdks.microsoftTeams ? styles.teams : ''}">
+    <section class="${styles.noFrameworkWebPart}">
       <div class="${styles.welcome}">
         <img alt="" src="${this._isDarkTheme ? welcomeDark : welcomeLight}" class="${styles.welcomeImage}" />
         <h2>${strings.GreetingMessage.replace(/\{0\}/g, escape(this.context.pageContext.user.displayName))}</h2>

--- a/examples/webpart-react/src/webparts/minimalWebPart/MinimalWebPart.ts
+++ b/examples/webpart-react/src/webparts/minimalWebPart/MinimalWebPart.ts
@@ -28,7 +28,6 @@ export default class MinimalWebPart extends BaseClientSideWebPart<IMinimalWebPar
         description: this.properties.description,
         isDarkTheme: this._isDarkTheme,
         environmentMessage: this._environmentMessage,
-        hasTeamsContext: !!this.context.sdks.microsoftTeams,
         userDisplayName: this.context.pageContext.user.displayName
       }
     );

--- a/examples/webpart-react/src/webparts/minimalWebPart/components/IMinimalProps.ts
+++ b/examples/webpart-react/src/webparts/minimalWebPart/components/IMinimalProps.ts
@@ -2,6 +2,5 @@ export interface IMinimalProps {
   description: string;
   isDarkTheme: boolean;
   environmentMessage: string;
-  hasTeamsContext: boolean;
   userDisplayName: string;
 }

--- a/examples/webpart-react/src/webparts/minimalWebPart/components/Minimal.module.scss
+++ b/examples/webpart-react/src/webparts/minimalWebPart/components/Minimal.module.scss
@@ -1,13 +1,8 @@
-@import '~@fluentui/react/dist/sass/References.scss';
-
 .minimal {
   overflow: hidden;
   padding: 1em;
   color: "[theme:bodyText, default: #323130]";
   color: var(--bodyText);
-  &.teams {
-    font-family: $ms-font-family-fallbacks;
-  }
 }
 
 .welcome {

--- a/examples/webpart-react/src/webparts/minimalWebPart/components/Minimal.tsx
+++ b/examples/webpart-react/src/webparts/minimalWebPart/components/Minimal.tsx
@@ -10,12 +10,11 @@ export default class Minimal extends React.Component<IMinimalProps> {
       description,
       isDarkTheme,
       environmentMessage,
-      hasTeamsContext,
       userDisplayName
     } = this.props;
 
     return (
-      <section className={`${styles.minimal} ${hasTeamsContext ? styles.teams : ''}`}>
+      <section className={`${styles.minimal}`}>
         <div className={styles.welcome}>
           <img alt="" src={isDarkTheme ? require('../assets/welcome-dark.png') : require('../assets/welcome-light.png')} className={styles.welcomeImage} />
           <h2>{strings.GreetingMessage.replace(/\{0\}/g, escape(userDisplayName))}</h2>

--- a/templates/webpart-noframework/src/webparts/{componentName.camel}WebPart/{componentName.pascal}WebPart.module.scss
+++ b/templates/webpart-noframework/src/webparts/{componentName.camel}WebPart/{componentName.pascal}WebPart.module.scss
@@ -1,13 +1,8 @@
-@import '~@microsoft/sp-office-ui-fabric-core/dist/sass/SPFabricCore.scss';
-
 .<%= componentName.camel %>WebPart {
   overflow: hidden;
   padding: 1em;
   color: "[theme:bodyText, default: #323130]";
   color: var(--bodyText);
-  &.teams {
-    font-family: $ms-font-family-fallbacks;
-  }
 }
 
 .welcome {

--- a/templates/webpart-noframework/src/webparts/{componentName.camel}WebPart/{componentName.pascal}WebPart.ts
+++ b/templates/webpart-noframework/src/webparts/{componentName.camel}WebPart/{componentName.pascal}WebPart.ts
@@ -23,7 +23,7 @@ export default class <%= componentName.pascal %>WebPart extends BaseClientSideWe
 
   public render(): void {
     this.domElement.innerHTML = `
-    <section class="${styles.<%= componentName.camel %>WebPart} ${!!this.context.sdks.microsoftTeams ? styles.teams : ''}">
+    <section class="${styles.<%= componentName.camel %>WebPart}">
       <div class="${styles.welcome}">
         <img alt="" src="${this._isDarkTheme ? welcomeDark : welcomeLight}" class="${styles.welcomeImage}" />
         <h2>${strings.GreetingMessage.replace(/\{0\}/g, escape(this.context.pageContext.user.displayName))}</h2>

--- a/templates/webpart-react/src/webparts/{componentName.camel}WebPart/components/I{componentName.pascal}Props.ts
+++ b/templates/webpart-react/src/webparts/{componentName.camel}WebPart/components/I{componentName.pascal}Props.ts
@@ -2,6 +2,5 @@ export interface I<%= componentName.pascal %>Props {
   description: string;
   isDarkTheme: boolean;
   environmentMessage: string;
-  hasTeamsContext: boolean;
   userDisplayName: string;
 }

--- a/templates/webpart-react/src/webparts/{componentName.camel}WebPart/components/{componentName.pascal}.module.scss
+++ b/templates/webpart-react/src/webparts/{componentName.camel}WebPart/components/{componentName.pascal}.module.scss
@@ -1,13 +1,8 @@
-@import '~@fluentui/react/dist/sass/References.scss';
-
 .<%= componentName.camel %> {
   overflow: hidden;
   padding: 1em;
   color: "[theme:bodyText, default: #323130]";
   color: var(--bodyText);
-  &.teams {
-    font-family: $ms-font-family-fallbacks;
-  }
 }
 
 .welcome {

--- a/templates/webpart-react/src/webparts/{componentName.camel}WebPart/components/{componentName.pascal}.tsx
+++ b/templates/webpart-react/src/webparts/{componentName.camel}WebPart/components/{componentName.pascal}.tsx
@@ -10,12 +10,11 @@ export default class <%= componentName.pascal %> extends React.Component<I<%= co
       description,
       isDarkTheme,
       environmentMessage,
-      hasTeamsContext,
       userDisplayName
     } = this.props;
 
     return (
-      <section className={`${styles.<%= componentName.camel %>} ${hasTeamsContext ? styles.teams : ''}`}>
+      <section className={`${styles.<%= componentName.camel %>}`}>
         <div className={styles.welcome}>
           <img alt="" src={isDarkTheme ? require('../assets/welcome-dark.png') : require('../assets/welcome-light.png')} className={styles.welcomeImage} />
           <h2>{strings.GreetingMessage.replace(/\{0\}/g, escape(userDisplayName))}</h2>

--- a/templates/webpart-react/src/webparts/{componentName.camel}WebPart/{componentName.pascal}WebPart.ts
+++ b/templates/webpart-react/src/webparts/{componentName.camel}WebPart/{componentName.pascal}WebPart.ts
@@ -28,7 +28,6 @@ export default class <%= componentName.pascal %>WebPart extends BaseClientSideWe
         description: this.properties.description,
         isDarkTheme: this._isDarkTheme,
         environmentMessage: this._environmentMessage,
-        hasTeamsContext: !!this.context.sdks.microsoftTeams,
         userDisplayName: this.context.pageContext.user.displayName
       }
     );


### PR DESCRIPTION
## Description
Removes the Microsoft Teams context handling from the `webpart-react` and `webpart-noframework` templates. The React template drops the `hasTeamsContext` prop from `IMinimalProps`, the web part's render data, and the destructured component props, along with the `${hasTeamsContext ? styles.teams : ''}` class toggle and the `&.teams` SCSS rule plus the `@import '~@fluentui/react/dist/sass/References.scss'`. The no-framework template removes the `this.context.sdks.microsoftTeams` class toggle in `render()`, the `&.teams` SCSS rule, and the `@import '~@microsoft/sp-office-ui-fabric-core/dist/sass/SPFabricCore.scss'`. The corresponding `examples/webpart-react` and `examples/webpart-noframework` were regenerated so they stay in sync with the templates. 

## How was this tested?
Regenerated both examples by running `spfx create` directly with `--local-source ./templates` and `SPFX_CI_MODE=1`, then ran the snapshot suite via `rushx build` in `tests/spfx-template-test` (19/19 tests passing), which scaffolds each template into a clean temp dir and compares it file-by-file against the committed examples. 

## Type of change 
- [ ] Bug fix 
- [ ] New feature / enhancement 
- [x] Template change 
- [ ] Documentation / CI / governance