### PR TITLE
feat: make --library-name optional, fallback to solution name

### DIFF
--- a/apps/spfx-cli/src/cli/actions/CreateAction.ts
+++ b/apps/spfx-cli/src/cli/actions/CreateAction.ts
@@ -48,7 +48,7 @@ const ScaffoldProfileSchema: z.ZodType<IScaffoldProfile> = z.object({
 export class CreateAction extends SPFxActionBase {
   private readonly _targetDirParameter: CommandLineStringParameter;
   private readonly _templateParameter: IRequiredCommandLineStringParameter;
-  private readonly _libraryNameParameter: IRequiredCommandLineStringParameter;
+  private readonly _libraryNameParameter: CommandLineStringParameter;
   private readonly _componentNameParameter: IRequiredCommandLineStringParameter;
   private readonly _componentAliasParameter: CommandLineStringParameter;
   private readonly _componentDescriptionParameter: CommandLineStringParameter;
@@ -83,8 +83,8 @@ export class CreateAction extends SPFxActionBase {
     this._libraryNameParameter = this.defineStringParameter({
       parameterLongName: '--library-name',
       argumentName: 'LIBRARY_NAME',
-      description: 'The library name for the component',
-      required: true
+      description: 'The library name for the component. Defaults to the solution name if not specified.',
+      required: false
     });
 
     this._componentNameParameter = this.defineStringParameter({
@@ -204,7 +204,7 @@ export class CreateAction extends SPFxActionBase {
       const builtInContext: ISPFxBuiltInContext = buildBuiltInContext(
         {
           componentName,
-          libraryName: this._libraryNameParameter.value,
+          libraryName: this._libraryNameParameter.value || solutionName,
           spfxVersion: template.spfxVersion,
           solutionName: rawSolutionName || undefined,
           componentAlias: this._componentAliasParameter.value?.trim() || undefined,

--- a/apps/spfx-cli/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/spfx-cli/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -4,8 +4,9 @@ exports[`CommandLineHelp prints the help: create 1`] = `
 "usage: spfx create [-h] [--template-url URL] [--spfx-version VERSION]
                    [--local-source TEMPLATE_PATH] [--remote-source URL]
                    [--github-token TOKEN] [--target-dir TARGET_DIR] --template
-                   TEMPLATE_NAME --library-name LIBRARY_NAME --component-name
-                   COMPONENT_NAME [--component-alias COMPONENT_ALIAS]
+                   TEMPLATE_NAME [--library-name LIBRARY_NAME]
+                   --component-name COMPONENT_NAME
+                   [--component-alias COMPONENT_ALIAS]
                    [--component-description COMPONENT_DESCRIPTION]
                    [--solution-name SOLUTION_NAME]
                    [--package-manager {npm,pnpm,yarn,none}]
@@ -40,7 +41,8 @@ Optional arguments:
   --template TEMPLATE_NAME
                         The template to use for scaffolding
   --library-name LIBRARY_NAME
-                        The library name for the component
+                        The library name for the component. Defaults to the
+                        solution name if not specified.
   --component-name COMPONENT_NAME
                         The component name (e.g., \\"Hello World\\")
   --component-alias COMPONENT_ALIAS

--- a/common/changes/@microsoft/spfx-cli/library-name-optional_2026-07-13.json
+++ b/common/changes/@microsoft/spfx-cli/library-name-optional_2026-07-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/spfx-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/spfx-cli"
+}


### PR DESCRIPTION
## Description
Makes `--library-name` optional on `spfx create`. When omitted, the solution name is used as the default library name instead of requiring explicit input.

Closes #246

## How was this tested?
- Change is scoped to CreateAction.ts only — parameter type changed from required to optional, fallback uses computed `solutionName`
- Verified the fallback path handles both missing `--library-name` and missing `--solution-name`
- Branch rebuilt off `main` to remove earlier cross-PR contamination — only this feature's changes are included

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Template change
- [ ] Documentation / CI / governance