### PR TITLE
Remove retired isDomainIsolated flag from scaffolded package-solution.json

### DIFF
--- a/examples/ace-data-visualization/config/package-solution.json
+++ b/examples/ace-data-visualization/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/ace-generic-card/config/package-solution.json
+++ b/examples/ace-generic-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/ace-generic-image-card/config/package-solution.json
+++ b/examples/ace-generic-image-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/ace-generic-primarytext-card/config/package-solution.json
+++ b/examples/ace-generic-primarytext-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/ace-search-card/config/package-solution.json
+++ b/examples/ace-search-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/copilot-component-minimal/config/package-solution.json
+++ b/examples/copilot-component-minimal/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/copilot-component-noframework/config/package-solution.json
+++ b/examples/copilot-component-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/copilot-component-react/config/package-solution.json
+++ b/examples/copilot-component-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-application-customizer/config/package-solution.json
+++ b/examples/extension-application-customizer/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-fieldcustomizer-minimal/config/package-solution.json
+++ b/examples/extension-fieldcustomizer-minimal/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-fieldcustomizer-noframework/config/package-solution.json
+++ b/examples/extension-fieldcustomizer-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-fieldcustomizer-react/config/package-solution.json
+++ b/examples/extension-fieldcustomizer-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-formcustomizer-noframework/config/package-solution.json
+++ b/examples/extension-formcustomizer-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-formcustomizer-react/config/package-solution.json
+++ b/examples/extension-formcustomizer-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-listviewcommandset/config/package-solution.json
+++ b/examples/extension-listviewcommandset/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/extension-search-query-modifier/config/package-solution.json
+++ b/examples/extension-search-query-modifier/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/library/config/package-solution.json
+++ b/examples/library/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/webpart-minimal/config/package-solution.json
+++ b/examples/webpart-minimal/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/webpart-noframework/config/package-solution.json
+++ b/examples/webpart-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/examples/webpart-react/config/package-solution.json
+++ b/examples/webpart-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/ace-data-visualization/config/package-solution.json
+++ b/templates/ace-data-visualization/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/ace-generic-card/config/package-solution.json
+++ b/templates/ace-generic-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/ace-generic-image-card/config/package-solution.json
+++ b/templates/ace-generic-image-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/ace-generic-primarytext-card/config/package-solution.json
+++ b/templates/ace-generic-primarytext-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/ace-search-card/config/package-solution.json
+++ b/templates/ace-search-card/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/copilot-component-minimal/config/package-solution.json
+++ b/templates/copilot-component-minimal/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/copilot-component-noframework/config/package-solution.json
+++ b/templates/copilot-component-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/copilot-component-react/config/package-solution.json
+++ b/templates/copilot-component-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-application-customizer/config/package-solution.json
+++ b/templates/extension-application-customizer/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-fieldcustomizer-minimal/config/package-solution.json
+++ b/templates/extension-fieldcustomizer-minimal/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-fieldcustomizer-noframework/config/package-solution.json
+++ b/templates/extension-fieldcustomizer-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-fieldcustomizer-react/config/package-solution.json
+++ b/templates/extension-fieldcustomizer-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-formcustomizer-noframework/config/package-solution.json
+++ b/templates/extension-formcustomizer-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-formcustomizer-react/config/package-solution.json
+++ b/templates/extension-formcustomizer-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-listviewcommandset/config/package-solution.json
+++ b/templates/extension-listviewcommandset/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/extension-search-query-modifier/config/package-solution.json
+++ b/templates/extension-search-query-modifier/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/library/config/package-solution.json
+++ b/templates/library/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/webpart-minimal/config/package-solution.json
+++ b/templates/webpart-minimal/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/webpart-noframework/config/package-solution.json
+++ b/templates/webpart-noframework/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/templates/webpart-react/config/package-solution.json
+++ b/templates/webpart-react/config/package-solution.json
@@ -6,7 +6,6 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false,
     "developer": {
       "name": "",
       "websiteUrl": "",

--- a/tests/spfx-template-test/src/tests/__snapshots__/multi-component.test.ts.snap
+++ b/tests/spfx-template-test/src/tests/__snapshots__/multi-component.test.ts.snap
@@ -66,7 +66,6 @@ Object {
     ],
     "id": "22222222-2222-2222-2222-222222222222",
     "includeClientSideAssets": true,
-    "isDomainIsolated": false,
     "metadata": Object {
       "categories": Array [],
       "longDescription": Object {


### PR DESCRIPTION
## Description
The domain-isolated web parts feature is retired. Freshly scaffolded SPFx solutions still emitted `"isDomainIsolated": false` in `config/package-solution.json`, which is dead surface area that confuses developers reading the manifest. This removes the flag from all scaffolding templates and their mirrored examples so new solutions no longer ship it.

Existing solutions that still carry the flag are unaffected — the property is tolerated and ignored by the build.

## Related
Companion platform-side change (Microsoft-internal Azure DevOps): removes `isDomainIsolated` from the SPFx generator/build pipeline and graduates the domain-isolated WP retirement flight — ODSP-Web PR 2331347: https://onedrive.visualstudio.com/ODSP-Web/_git/odsp-web/pullrequest/2331347

## How was this tested
- Verified no `isDomainIsolated` remains under `templates/` or `examples/`.
- Confirmed all 40 modified `package-solution.json` files still parse as valid JSON.
- Templates and examples kept in sync (20 + 20).

## Type of change
- [x] Template change

Draft — not for review yet.